### PR TITLE
Refactor `ast::constant_value`

### DIFF
--- a/include/bz/variant.h
+++ b/include/bz/variant.h
@@ -351,13 +351,20 @@ public:
 	}
 };
 
+template<typename T>
+constexpr bool is_trivial_variant = std::is_trivially_destructible_v<T>
+	&& std::is_trivially_copy_constructible_v<T>
+	&& std::is_trivially_copy_assignable_v<T>
+	&& std::is_trivially_move_constructible_v<T>
+	&& std::is_trivially_move_assignable_v<T>;
+
 } // namespace internal
 
 
 template<typename ...Ts>
 class variant :
 	public meta::conditional<
-		internal::is_all({ meta::is_trivial_v<Ts>... }),
+		internal::is_all({ internal::is_trivial_variant<Ts>... }),
 		internal::variant_trivial_base<Ts...>,
 		internal::variant_non_trivial_base<Ts...>
 	>
@@ -373,7 +380,7 @@ class variant :
 private:
 	using self_t = variant<Ts...>;
 	using base_t = meta::conditional<
-		internal::is_all({ meta::is_trivial_v<Ts>... }),
+		internal::is_all({ internal::is_trivial_variant<Ts>... }),
 		internal::variant_trivial_base<Ts...>,
 		internal::variant_non_trivial_base<Ts...>
 	>;

--- a/src/ast/constant_value.cpp
+++ b/src/ast/constant_value.cpp
@@ -5,7 +5,7 @@
 namespace ast
 {
 
-static bz::u8string get_aggregate_like_value_string(bz::array_view<constant_value const> values)
+static bz::u8string get_aggregate_like_value_string(bz::array_view<constant_value_storage const> values)
 {
 	if (values.empty())
 	{
@@ -58,30 +58,30 @@ static bz::u8string get_aggregate_like_value_string(bz::array_view<T const> valu
 	return result;
 }
 
-bz::u8string get_value_string(constant_value const &value)
+bz::u8string get_value_string(constant_value_storage const &value)
 {
 	switch (value.kind())
 	{
-	static_assert(constant_value::variant_count == 19);
-	case constant_value::sint:
+	static_assert(constant_value_storage::variant_count == 19);
+	case constant_value_storage::sint:
 		return bz::format("{}", value.get_sint());
-	case constant_value::uint:
+	case constant_value_storage::uint:
 		return bz::format("{}", value.get_uint());
-	case constant_value::float32:
+	case constant_value_storage::float32:
 		return bz::format("{}", value.get_float32());
-	case constant_value::float64:
+	case constant_value_storage::float64:
 		return bz::format("{}", value.get_float64());
-	case constant_value::u8char:
+	case constant_value_storage::u8char:
 		return bz::format("'{}'", add_escape_sequences(value.get_u8char()));
-	case constant_value::string:
+	case constant_value_storage::string:
 		return bz::format("\"{}\"", add_escape_sequences(value.get_string()));
-	case constant_value::boolean:
+	case constant_value_storage::boolean:
 		return bz::format("{}", value.get_boolean());
-	case constant_value::null:
+	case constant_value_storage::null:
 		return "null";
-	case constant_value::void_:
+	case constant_value_storage::void_:
 		return "void()";
-	case constant_value::enum_:
+	case constant_value_storage::enum_:
 	{
 		auto const [decl, enum_value] = value.get_enum();
 		auto const value_name = decl->get_value_name(enum_value);
@@ -103,36 +103,36 @@ bz::u8string get_value_string(constant_value const &value)
 			}
 		}
 	}
-	case constant_value::array:
+	case constant_value_storage::array:
 		return get_aggregate_like_value_string(value.get_array());
-	case constant_value::sint_array:
+	case constant_value_storage::sint_array:
 		return get_aggregate_like_value_string(value.get_sint_array());
-	case constant_value::uint_array:
+	case constant_value_storage::uint_array:
 		return get_aggregate_like_value_string(value.get_uint_array());
-	case constant_value::float32_array:
+	case constant_value_storage::float32_array:
 		return get_aggregate_like_value_string(value.get_float32_array());
-	case constant_value::float64_array:
+	case constant_value_storage::float64_array:
 		return get_aggregate_like_value_string(value.get_float64_array());
-	case constant_value::tuple:
+	case constant_value_storage::tuple:
 		return get_aggregate_like_value_string(value.get_tuple());
-	case constant_value::function:
+	case constant_value_storage::function:
 		return "";
-	case constant_value::type:
+	case constant_value_storage::type:
 		return bz::format("{}", value.get_type());
-	case constant_value::aggregate:
+	case constant_value_storage::aggregate:
 		return get_aggregate_like_value_string(value.get_aggregate());
 	default:
 		return "";
 	}
 }
 
-static void encode_array_like(bz::u8string &out, bz::array_view<constant_value const> values)
+static void encode_array_like(bz::u8string &out, bz::array_view<constant_value_storage const> values)
 {
 	out += bz::format("{}", values.size());
 	for (auto const &value : values)
 	{
 		out += '.';
-		constant_value::encode_for_symbol_name(out, value);
+		constant_value_storage::encode_for_symbol_name(out, value);
 	}
 }
 
@@ -176,11 +176,11 @@ static void encode_array_like(bz::u8string &out, bz::array_view<float64_t const>
 	}
 }
 
-void constant_value::encode_for_symbol_name(bz::u8string &out, constant_value const &value)
+void constant_value_storage::encode_for_symbol_name(bz::u8string &out, constant_value_storage const &value)
 {
 	switch (value.kind())
 	{
-	static_assert(constant_value::variant_count == 19);
+	static_assert(constant_value_storage::variant_count == 19);
 	case sint:
 		out += 'i';
 		out += bz::format("{}", bit_cast<uint64_t>(value.get_sint()));
@@ -354,7 +354,7 @@ static void decode_array_like(
 		}
 		bz_assert(*it == '.');
 		++it;
-		out += constant_value::decode_from_symbol_name(it, end);
+		out += constant_value_storage::decode_from_symbol_name(it, end);
 	}
 	out += " ]";
 }
@@ -443,9 +443,9 @@ static void decode_float64_array(
 	out += " ]";
 }
 
-bz::u8string constant_value::decode_from_symbol_name(bz::u8string_view::const_iterator &it, bz::u8string_view::const_iterator end)
+bz::u8string constant_value_storage::decode_from_symbol_name(bz::u8string_view::const_iterator &it, bz::u8string_view::const_iterator end)
 {
-	static_assert(constant_value::variant_count == 19);
+	static_assert(constant_value_storage::variant_count == 19);
 	switch (*it)
 	{
 	case 'i':
@@ -590,7 +590,7 @@ bz::u8string constant_value::decode_from_symbol_name(bz::u8string_view::const_it
 	}
 }
 
-bool operator == (constant_value const &lhs, constant_value const &rhs) noexcept
+bool operator == (constant_value_storage const &lhs, constant_value_storage const &rhs) noexcept
 {
 	if (lhs.kind() != rhs.kind())
 	{
@@ -598,55 +598,55 @@ bool operator == (constant_value const &lhs, constant_value const &rhs) noexcept
 	}
 	switch (lhs.kind())
 	{
-	static_assert(constant_value::variant_count == 19);
-	case constant_value::sint:
+	static_assert(constant_value_storage::variant_count == 19);
+	case constant_value_storage::sint:
 		return lhs.get_sint() == rhs.get_sint();
-	case constant_value::uint:
+	case constant_value_storage::uint:
 		return lhs.get_uint() == rhs.get_uint();
-	case constant_value::float32:
+	case constant_value_storage::float32:
 		return lhs.get_float32() == rhs.get_float32();
-	case constant_value::float64:
+	case constant_value_storage::float64:
 		return lhs.get_float64() == rhs.get_float64();
-	case constant_value::u8char:
+	case constant_value_storage::u8char:
 		return lhs.get_u8char() == rhs.get_u8char();
-	case constant_value::string:
+	case constant_value_storage::string:
 		return lhs.get_string() == rhs.get_string();
-	case constant_value::boolean:
+	case constant_value_storage::boolean:
 		return lhs.get_boolean() == rhs.get_boolean();
-	case constant_value::null:
+	case constant_value_storage::null:
 		return true;
-	case constant_value::void_:
+	case constant_value_storage::void_:
 		return true;
-	case constant_value::enum_:
+	case constant_value_storage::enum_:
 	{
 		auto const [lhs_decl, lhs_value] = lhs.get_enum();
 		auto const [rhs_decl, rhs_value] = rhs.get_enum();
 		return lhs_decl == rhs_decl && lhs_value == rhs_value;
 	}
-	case constant_value::array:
+	case constant_value_storage::array:
 		return lhs.get_array() == rhs.get_array();
-	case constant_value::sint_array:
+	case constant_value_storage::sint_array:
 		return lhs.get_sint_array() == rhs.get_sint_array();
-	case constant_value::uint_array:
+	case constant_value_storage::uint_array:
 		return lhs.get_uint_array() == rhs.get_uint_array();
-	case constant_value::float32_array:
+	case constant_value_storage::float32_array:
 		return lhs.get_float32_array() == rhs.get_float32_array();
-	case constant_value::float64_array:
+	case constant_value_storage::float64_array:
 		return lhs.get_float64_array() == rhs.get_float64_array();
-	case constant_value::tuple:
+	case constant_value_storage::tuple:
 		return lhs.get_tuple() == rhs.get_tuple();
-	case constant_value::function:
+	case constant_value_storage::function:
 		return lhs.get_function() == rhs.get_function();
-	case constant_value::type:
+	case constant_value_storage::type:
 		return lhs.get_type() == rhs.get_type();
-	case constant_value::aggregate:
+	case constant_value_storage::aggregate:
 		return lhs.get_aggregate() == rhs.get_aggregate();
 	default:
 		return false;
 	}
 }
 
-bool operator != (constant_value const &lhs, constant_value const &rhs) noexcept
+bool operator != (constant_value_storage const &lhs, constant_value_storage const &rhs) noexcept
 {
 	return !(lhs == rhs);
 }

--- a/src/ast/constant_value.cpp
+++ b/src/ast/constant_value.cpp
@@ -7,36 +7,7 @@ namespace ast
 
 static_assert(std::is_trivially_copy_constructible_v<constant_value_base_t>);
 
-static_assert(constant_value_storage_base_t::variant_count == 19);
-static_assert(static_cast<uint64_t>(constant_value_kind::sint) == constant_value_storage_base_t::index_of<int64_t>);
-static_assert(static_cast<uint64_t>(constant_value_kind::uint) == constant_value_storage_base_t::index_of<uint64_t>);
-static_assert(static_cast<uint64_t>(constant_value_kind::float32) == constant_value_storage_base_t::index_of<float32_t>);
-static_assert(static_cast<uint64_t>(constant_value_kind::float64) == constant_value_storage_base_t::index_of<float64_t>);
-static_assert(static_cast<uint64_t>(constant_value_kind::u8char) == constant_value_storage_base_t::index_of<bz::u8char>);
-static_assert(static_cast<uint64_t>(constant_value_kind::string) == constant_value_storage_base_t::index_of<bz::u8string>);
-static_assert(static_cast<uint64_t>(constant_value_kind::boolean) == constant_value_storage_base_t::index_of<bool>);
-static_assert(static_cast<uint64_t>(constant_value_kind::null) == constant_value_storage_base_t::index_of<internal::null_t>);
-static_assert(static_cast<uint64_t>(constant_value_kind::void_) == constant_value_storage_base_t::index_of<internal::void_t>);
-static_assert(static_cast<uint64_t>(constant_value_kind::enum_) == constant_value_storage_base_t::index_of<internal::enum_t>);
-// static_assert(static_cast<uint64_t>(constant_value_kind::array) == constant_value_storage_base_t::index_of<arena_vector<constant_value_storage>>);
-static_assert(static_cast<uint64_t>(constant_value_kind::sint_array) == constant_value_storage_base_t::index_of<arena_vector<int64_t>>);
-static_assert(static_cast<uint64_t>(constant_value_kind::uint_array) == constant_value_storage_base_t::index_of<arena_vector<uint64_t>>);
-static_assert(static_cast<uint64_t>(constant_value_kind::float32_array) == constant_value_storage_base_t::index_of<arena_vector<float32_t>>);
-static_assert(static_cast<uint64_t>(constant_value_kind::float64_array) == constant_value_storage_base_t::index_of<arena_vector<float64_t>>);
-// static_assert(static_cast<uint64_t>(constant_value_kind::tuple) == constant_value_storage_base_t::index_of<arena_vector<constant_value_storage>>);
-static_assert(static_cast<uint64_t>(constant_value_kind::function) == constant_value_storage_base_t::index_of<function_body *>);
-static_assert(static_cast<uint64_t>(constant_value_kind::type) == constant_value_storage_base_t::index_of<typespec>);
-// static_assert(static_cast<uint64_t>(constant_value_kind::aggregate) == constant_value_storage_base_t::index_of<arena_vector<constant_value_storage>>);
-static_assert(bz::meta::is_same<constant_value_storage_base_t::value_type<static_cast<uint64_t>(constant_value_kind::array)>, arena_vector<constant_value_storage>>);
-static_assert(bz::meta::is_same<constant_value_storage_base_t::value_type<static_cast<uint64_t>(constant_value_kind::tuple)>, arena_vector<constant_value_storage>>);
-static_assert(bz::meta::is_same<constant_value_storage_base_t::value_type<static_cast<uint64_t>(constant_value_kind::aggregate)>, arena_vector<constant_value_storage>>);
-static_assert(
-	constant_value_kind::array != constant_value_kind::tuple
-	&& constant_value_kind::array != constant_value_kind::aggregate
-	&& constant_value_kind::tuple != constant_value_kind::aggregate
-);
-
-static_assert(constant_value_base_t::variant_count == 19);
+static_assert(constant_value::variant_count == 19);
 static_assert(static_cast<uint64_t>(constant_value_kind::sint) == constant_value_base_t::index_of<int64_t>);
 static_assert(static_cast<uint64_t>(constant_value_kind::uint) == constant_value_base_t::index_of<uint64_t>);
 static_assert(static_cast<uint64_t>(constant_value_kind::float32) == constant_value_base_t::index_of<float32_t>);
@@ -47,73 +18,25 @@ static_assert(static_cast<uint64_t>(constant_value_kind::boolean) == constant_va
 static_assert(static_cast<uint64_t>(constant_value_kind::null) == constant_value_base_t::index_of<internal::null_t>);
 static_assert(static_cast<uint64_t>(constant_value_kind::void_) == constant_value_base_t::index_of<internal::void_t>);
 static_assert(static_cast<uint64_t>(constant_value_kind::enum_) == constant_value_base_t::index_of<internal::enum_t>);
-// static_assert(static_cast<uint64_t>(constant_value_kind::array) == constant_value_base_t::index_of<bz::array_view<constant_value_storage const>>);
+// static_assert(static_cast<uint64_t>(constant_value_kind::array) == constant_value_base_t::index_of<bz::array_view<constant_value const>>);
 static_assert(static_cast<uint64_t>(constant_value_kind::sint_array) == constant_value_base_t::index_of<bz::array_view<int64_t const>>);
 static_assert(static_cast<uint64_t>(constant_value_kind::uint_array) == constant_value_base_t::index_of<bz::array_view<uint64_t const>>);
 static_assert(static_cast<uint64_t>(constant_value_kind::float32_array) == constant_value_base_t::index_of<bz::array_view<float32_t const>>);
 static_assert(static_cast<uint64_t>(constant_value_kind::float64_array) == constant_value_base_t::index_of<bz::array_view<float64_t const>>);
-// static_assert(static_cast<uint64_t>(constant_value_kind::tuple) == constant_value_base_t::index_of<bz::array_view<constant_value_storage const>>);
+// static_assert(static_cast<uint64_t>(constant_value_kind::tuple) == constant_value_base_t::index_of<bz::array_view<constant_value const>>);
 static_assert(static_cast<uint64_t>(constant_value_kind::function) == constant_value_base_t::index_of<function_body *>);
 static_assert(static_cast<uint64_t>(constant_value_kind::type) == constant_value_base_t::index_of<typespec_view>);
-// static_assert(static_cast<uint64_t>(constant_value_kind::aggregate) == constant_value_base_t::index_of<bz::array_view<constant_value_storage const>>);
-static_assert(bz::meta::is_same<constant_value_base_t::value_type<static_cast<uint64_t>(constant_value_kind::array)>, bz::array_view<constant_value_storage const>>);
-static_assert(bz::meta::is_same<constant_value_base_t::value_type<static_cast<uint64_t>(constant_value_kind::tuple)>, bz::array_view<constant_value_storage const>>);
-static_assert(bz::meta::is_same<constant_value_base_t::value_type<static_cast<uint64_t>(constant_value_kind::aggregate)>, bz::array_view<constant_value_storage const>>);
+// static_assert(static_cast<uint64_t>(constant_value_kind::aggregate) == constant_value_base_t::index_of<bz::array_view<constant_value const>>);
+static_assert(bz::meta::is_same<constant_value_base_t::value_type<static_cast<uint64_t>(constant_value_kind::array)>, bz::array_view<constant_value const>>);
+static_assert(bz::meta::is_same<constant_value_base_t::value_type<static_cast<uint64_t>(constant_value_kind::tuple)>, bz::array_view<constant_value const>>);
+static_assert(bz::meta::is_same<constant_value_base_t::value_type<static_cast<uint64_t>(constant_value_kind::aggregate)>, bz::array_view<constant_value const>>);
 static_assert(
 	constant_value_kind::array != constant_value_kind::tuple
 	&& constant_value_kind::array != constant_value_kind::aggregate
 	&& constant_value_kind::tuple != constant_value_kind::aggregate
 );
 
-constant_value constant_value_storage::as_constant_value(void) const
-{
-	switch (this->kind())
-	{
-	static_assert(constant_value_storage_base_t::variant_count == 19);
-	case constant_value_kind::sint:
-		return constant_value(this->get_sint());
-	case constant_value_kind::uint:
-		return constant_value(this->get_uint());
-	case constant_value_kind::float32:
-		return constant_value(this->get_float32());
-	case constant_value_kind::float64:
-		return constant_value(this->get_float64());
-	case constant_value_kind::u8char:
-		return constant_value(this->get_u8char());
-	case constant_value_kind::string:
-		return constant_value(this->get_string());
-	case constant_value_kind::boolean:
-		return constant_value(this->get_boolean());
-	case constant_value_kind::null:
-		return constant_value::get_null();
-	case constant_value_kind::void_:
-		return constant_value::get_void();
-	case constant_value_kind::enum_:
-		return constant_value(this->get_enum());
-	case constant_value_kind::array:
-		return constant_value(this->get_array());
-	case constant_value_kind::sint_array:
-		return constant_value(this->get_sint_array());
-	case constant_value_kind::uint_array:
-		return constant_value(this->get_uint_array());
-	case constant_value_kind::float32_array:
-		return constant_value(this->get_float32_array());
-	case constant_value_kind::float64_array:
-		return constant_value(this->get_float64_array());
-	case constant_value_kind::tuple:
-		return constant_value(this->get_tuple());
-	case constant_value_kind::function:
-		return constant_value(this->get_function());
-	case constant_value_kind::type:
-		return constant_value(this->get_type());
-	case constant_value_kind::aggregate:
-		return constant_value(this->get_aggregate());
-	default:
-		return constant_value();
-	}
-}
-
-static bz::u8string get_aggregate_like_value_string(bz::array_view<constant_value_storage const> values)
+static bz::u8string get_aggregate_like_value_string(bz::array_view<constant_value const> values)
 {
 	if (values.empty())
 	{
@@ -166,11 +89,11 @@ static bz::u8string get_aggregate_like_value_string(bz::array_view<T const> valu
 	return result;
 }
 
-bz::u8string get_value_string(constant_value_storage const &value)
+bz::u8string get_value_string(constant_value const &value)
 {
 	switch (value.kind())
 	{
-	static_assert(constant_value_storage::variant_count == 19);
+	static_assert(constant_value::variant_count == 19);
 	case constant_value_kind::sint:
 		return bz::format("{}", value.get_sint());
 	case constant_value_kind::uint:
@@ -234,13 +157,13 @@ bz::u8string get_value_string(constant_value_storage const &value)
 	}
 }
 
-static void encode_array_like(bz::u8string &out, bz::array_view<constant_value_storage const> values)
+static void encode_array_like(bz::u8string &out, bz::array_view<constant_value const> values)
 {
 	out += bz::format("{}", values.size());
 	for (auto const &value : values)
 	{
 		out += '.';
-		constant_value_storage::encode_for_symbol_name(out, value);
+		constant_value::encode_for_symbol_name(out, value);
 	}
 }
 
@@ -284,11 +207,11 @@ static void encode_array_like(bz::u8string &out, bz::array_view<float64_t const>
 	}
 }
 
-void constant_value_storage::encode_for_symbol_name(bz::u8string &out, constant_value_storage const &value)
+void constant_value::encode_for_symbol_name(bz::u8string &out, constant_value const &value)
 {
 	switch (value.kind())
 	{
-	static_assert(constant_value_storage::variant_count == 19);
+	static_assert(constant_value::variant_count == 19);
 	case constant_value_kind::sint:
 		out += 'i';
 		out += bz::format("{}", bit_cast<uint64_t>(value.get_sint()));
@@ -462,7 +385,7 @@ static void decode_array_like(
 		}
 		bz_assert(*it == '.');
 		++it;
-		out += constant_value_storage::decode_from_symbol_name(it, end);
+		out += constant_value::decode_from_symbol_name(it, end);
 	}
 	out += " ]";
 }
@@ -551,9 +474,9 @@ static void decode_float64_array(
 	out += " ]";
 }
 
-bz::u8string constant_value_storage::decode_from_symbol_name(bz::u8string_view::const_iterator &it, bz::u8string_view::const_iterator end)
+bz::u8string constant_value::decode_from_symbol_name(bz::u8string_view::const_iterator &it, bz::u8string_view::const_iterator end)
 {
-	static_assert(constant_value_storage::variant_count == 19);
+	static_assert(constant_value::variant_count == 19);
 	switch (*it)
 	{
 	case 'i':
@@ -706,7 +629,7 @@ bool operator == (constant_value const &lhs, constant_value const &rhs) noexcept
 	}
 	switch (lhs.kind())
 	{
-	static_assert(constant_value_storage::variant_count == 19);
+	static_assert(constant_value::variant_count == 19);
 	case constant_value_kind::sint:
 		return lhs.get_sint() == rhs.get_sint();
 	case constant_value_kind::uint:
@@ -757,16 +680,6 @@ bool operator == (constant_value const &lhs, constant_value const &rhs) noexcept
 bool operator != (constant_value const &lhs, constant_value const &rhs) noexcept
 {
 	return !(lhs == rhs);
-}
-
-bool operator == (constant_value_storage const &lhs, constant_value_storage const &rhs) noexcept
-{
-	return lhs.kind() == rhs.kind() && lhs.as_constant_value() == rhs.as_constant_value();
-}
-
-bool operator != (constant_value_storage const &lhs, constant_value_storage const &rhs) noexcept
-{
-	return lhs.kind() != rhs.kind() || lhs.as_constant_value() != rhs.as_constant_value();
 }
 
 } // namespace ast

--- a/src/ast/constant_value.cpp
+++ b/src/ast/constant_value.cpp
@@ -5,6 +5,114 @@
 namespace ast
 {
 
+static_assert(std::is_trivially_copy_constructible_v<constant_value_base_t>);
+
+static_assert(constant_value_storage_base_t::variant_count == 19);
+static_assert(static_cast<uint64_t>(constant_value_kind::sint) == constant_value_storage_base_t::index_of<int64_t>);
+static_assert(static_cast<uint64_t>(constant_value_kind::uint) == constant_value_storage_base_t::index_of<uint64_t>);
+static_assert(static_cast<uint64_t>(constant_value_kind::float32) == constant_value_storage_base_t::index_of<float32_t>);
+static_assert(static_cast<uint64_t>(constant_value_kind::float64) == constant_value_storage_base_t::index_of<float64_t>);
+static_assert(static_cast<uint64_t>(constant_value_kind::u8char) == constant_value_storage_base_t::index_of<bz::u8char>);
+static_assert(static_cast<uint64_t>(constant_value_kind::string) == constant_value_storage_base_t::index_of<bz::u8string>);
+static_assert(static_cast<uint64_t>(constant_value_kind::boolean) == constant_value_storage_base_t::index_of<bool>);
+static_assert(static_cast<uint64_t>(constant_value_kind::null) == constant_value_storage_base_t::index_of<internal::null_t>);
+static_assert(static_cast<uint64_t>(constant_value_kind::void_) == constant_value_storage_base_t::index_of<internal::void_t>);
+static_assert(static_cast<uint64_t>(constant_value_kind::enum_) == constant_value_storage_base_t::index_of<internal::enum_t>);
+// static_assert(static_cast<uint64_t>(constant_value_kind::array) == constant_value_storage_base_t::index_of<arena_vector<constant_value_storage>>);
+static_assert(static_cast<uint64_t>(constant_value_kind::sint_array) == constant_value_storage_base_t::index_of<arena_vector<int64_t>>);
+static_assert(static_cast<uint64_t>(constant_value_kind::uint_array) == constant_value_storage_base_t::index_of<arena_vector<uint64_t>>);
+static_assert(static_cast<uint64_t>(constant_value_kind::float32_array) == constant_value_storage_base_t::index_of<arena_vector<float32_t>>);
+static_assert(static_cast<uint64_t>(constant_value_kind::float64_array) == constant_value_storage_base_t::index_of<arena_vector<float64_t>>);
+// static_assert(static_cast<uint64_t>(constant_value_kind::tuple) == constant_value_storage_base_t::index_of<arena_vector<constant_value_storage>>);
+static_assert(static_cast<uint64_t>(constant_value_kind::function) == constant_value_storage_base_t::index_of<function_body *>);
+static_assert(static_cast<uint64_t>(constant_value_kind::type) == constant_value_storage_base_t::index_of<typespec>);
+// static_assert(static_cast<uint64_t>(constant_value_kind::aggregate) == constant_value_storage_base_t::index_of<arena_vector<constant_value_storage>>);
+static_assert(bz::meta::is_same<constant_value_storage_base_t::value_type<static_cast<uint64_t>(constant_value_kind::array)>, arena_vector<constant_value_storage>>);
+static_assert(bz::meta::is_same<constant_value_storage_base_t::value_type<static_cast<uint64_t>(constant_value_kind::tuple)>, arena_vector<constant_value_storage>>);
+static_assert(bz::meta::is_same<constant_value_storage_base_t::value_type<static_cast<uint64_t>(constant_value_kind::aggregate)>, arena_vector<constant_value_storage>>);
+static_assert(
+	constant_value_kind::array != constant_value_kind::tuple
+	&& constant_value_kind::array != constant_value_kind::aggregate
+	&& constant_value_kind::tuple != constant_value_kind::aggregate
+);
+
+static_assert(constant_value_base_t::variant_count == 19);
+static_assert(static_cast<uint64_t>(constant_value_kind::sint) == constant_value_base_t::index_of<int64_t>);
+static_assert(static_cast<uint64_t>(constant_value_kind::uint) == constant_value_base_t::index_of<uint64_t>);
+static_assert(static_cast<uint64_t>(constant_value_kind::float32) == constant_value_base_t::index_of<float32_t>);
+static_assert(static_cast<uint64_t>(constant_value_kind::float64) == constant_value_base_t::index_of<float64_t>);
+static_assert(static_cast<uint64_t>(constant_value_kind::u8char) == constant_value_base_t::index_of<bz::u8char>);
+static_assert(static_cast<uint64_t>(constant_value_kind::string) == constant_value_base_t::index_of<bz::u8string_view>);
+static_assert(static_cast<uint64_t>(constant_value_kind::boolean) == constant_value_base_t::index_of<bool>);
+static_assert(static_cast<uint64_t>(constant_value_kind::null) == constant_value_base_t::index_of<internal::null_t>);
+static_assert(static_cast<uint64_t>(constant_value_kind::void_) == constant_value_base_t::index_of<internal::void_t>);
+static_assert(static_cast<uint64_t>(constant_value_kind::enum_) == constant_value_base_t::index_of<internal::enum_t>);
+// static_assert(static_cast<uint64_t>(constant_value_kind::array) == constant_value_base_t::index_of<bz::array_view<constant_value_storage const>>);
+static_assert(static_cast<uint64_t>(constant_value_kind::sint_array) == constant_value_base_t::index_of<bz::array_view<int64_t const>>);
+static_assert(static_cast<uint64_t>(constant_value_kind::uint_array) == constant_value_base_t::index_of<bz::array_view<uint64_t const>>);
+static_assert(static_cast<uint64_t>(constant_value_kind::float32_array) == constant_value_base_t::index_of<bz::array_view<float32_t const>>);
+static_assert(static_cast<uint64_t>(constant_value_kind::float64_array) == constant_value_base_t::index_of<bz::array_view<float64_t const>>);
+// static_assert(static_cast<uint64_t>(constant_value_kind::tuple) == constant_value_base_t::index_of<bz::array_view<constant_value_storage const>>);
+static_assert(static_cast<uint64_t>(constant_value_kind::function) == constant_value_base_t::index_of<function_body *>);
+static_assert(static_cast<uint64_t>(constant_value_kind::type) == constant_value_base_t::index_of<typespec_view>);
+// static_assert(static_cast<uint64_t>(constant_value_kind::aggregate) == constant_value_base_t::index_of<bz::array_view<constant_value_storage const>>);
+static_assert(bz::meta::is_same<constant_value_base_t::value_type<static_cast<uint64_t>(constant_value_kind::array)>, bz::array_view<constant_value_storage const>>);
+static_assert(bz::meta::is_same<constant_value_base_t::value_type<static_cast<uint64_t>(constant_value_kind::tuple)>, bz::array_view<constant_value_storage const>>);
+static_assert(bz::meta::is_same<constant_value_base_t::value_type<static_cast<uint64_t>(constant_value_kind::aggregate)>, bz::array_view<constant_value_storage const>>);
+static_assert(
+	constant_value_kind::array != constant_value_kind::tuple
+	&& constant_value_kind::array != constant_value_kind::aggregate
+	&& constant_value_kind::tuple != constant_value_kind::aggregate
+);
+
+constant_value constant_value_storage::as_constant_value(void) const
+{
+	switch (this->kind())
+	{
+	static_assert(constant_value_storage_base_t::variant_count == 19);
+	case constant_value_kind::sint:
+		return constant_value(this->get_sint());
+	case constant_value_kind::uint:
+		return constant_value(this->get_uint());
+	case constant_value_kind::float32:
+		return constant_value(this->get_float32());
+	case constant_value_kind::float64:
+		return constant_value(this->get_float64());
+	case constant_value_kind::u8char:
+		return constant_value(this->get_u8char());
+	case constant_value_kind::string:
+		return constant_value(this->get_string());
+	case constant_value_kind::boolean:
+		return constant_value(this->get_boolean());
+	case constant_value_kind::null:
+		return constant_value::get_null();
+	case constant_value_kind::void_:
+		return constant_value::get_void();
+	case constant_value_kind::enum_:
+		return constant_value(this->get_enum());
+	case constant_value_kind::array:
+		return constant_value(this->get_array());
+	case constant_value_kind::sint_array:
+		return constant_value(this->get_sint_array());
+	case constant_value_kind::uint_array:
+		return constant_value(this->get_uint_array());
+	case constant_value_kind::float32_array:
+		return constant_value(this->get_float32_array());
+	case constant_value_kind::float64_array:
+		return constant_value(this->get_float64_array());
+	case constant_value_kind::tuple:
+		return constant_value(this->get_tuple());
+	case constant_value_kind::function:
+		return constant_value(this->get_function());
+	case constant_value_kind::type:
+		return constant_value(this->get_type());
+	case constant_value_kind::aggregate:
+		return constant_value(this->get_aggregate());
+	default:
+		return constant_value();
+	}
+}
+
 static bz::u8string get_aggregate_like_value_string(bz::array_view<constant_value_storage const> values)
 {
 	if (values.empty())
@@ -63,25 +171,25 @@ bz::u8string get_value_string(constant_value_storage const &value)
 	switch (value.kind())
 	{
 	static_assert(constant_value_storage::variant_count == 19);
-	case constant_value_storage::sint:
+	case constant_value_kind::sint:
 		return bz::format("{}", value.get_sint());
-	case constant_value_storage::uint:
+	case constant_value_kind::uint:
 		return bz::format("{}", value.get_uint());
-	case constant_value_storage::float32:
+	case constant_value_kind::float32:
 		return bz::format("{}", value.get_float32());
-	case constant_value_storage::float64:
+	case constant_value_kind::float64:
 		return bz::format("{}", value.get_float64());
-	case constant_value_storage::u8char:
+	case constant_value_kind::u8char:
 		return bz::format("'{}'", add_escape_sequences(value.get_u8char()));
-	case constant_value_storage::string:
+	case constant_value_kind::string:
 		return bz::format("\"{}\"", add_escape_sequences(value.get_string()));
-	case constant_value_storage::boolean:
+	case constant_value_kind::boolean:
 		return bz::format("{}", value.get_boolean());
-	case constant_value_storage::null:
+	case constant_value_kind::null:
 		return "null";
-	case constant_value_storage::void_:
+	case constant_value_kind::void_:
 		return "void()";
-	case constant_value_storage::enum_:
+	case constant_value_kind::enum_:
 	{
 		auto const [decl, enum_value] = value.get_enum();
 		auto const value_name = decl->get_value_name(enum_value);
@@ -103,23 +211,23 @@ bz::u8string get_value_string(constant_value_storage const &value)
 			}
 		}
 	}
-	case constant_value_storage::array:
+	case constant_value_kind::array:
 		return get_aggregate_like_value_string(value.get_array());
-	case constant_value_storage::sint_array:
+	case constant_value_kind::sint_array:
 		return get_aggregate_like_value_string(value.get_sint_array());
-	case constant_value_storage::uint_array:
+	case constant_value_kind::uint_array:
 		return get_aggregate_like_value_string(value.get_uint_array());
-	case constant_value_storage::float32_array:
+	case constant_value_kind::float32_array:
 		return get_aggregate_like_value_string(value.get_float32_array());
-	case constant_value_storage::float64_array:
+	case constant_value_kind::float64_array:
 		return get_aggregate_like_value_string(value.get_float64_array());
-	case constant_value_storage::tuple:
+	case constant_value_kind::tuple:
 		return get_aggregate_like_value_string(value.get_tuple());
-	case constant_value_storage::function:
+	case constant_value_kind::function:
 		return "";
-	case constant_value_storage::type:
+	case constant_value_kind::type:
 		return bz::format("{}", value.get_type());
-	case constant_value_storage::aggregate:
+	case constant_value_kind::aggregate:
 		return get_aggregate_like_value_string(value.get_aggregate());
 	default:
 		return "";
@@ -181,27 +289,27 @@ void constant_value_storage::encode_for_symbol_name(bz::u8string &out, constant_
 	switch (value.kind())
 	{
 	static_assert(constant_value_storage::variant_count == 19);
-	case sint:
+	case constant_value_kind::sint:
 		out += 'i';
 		out += bz::format("{}", bit_cast<uint64_t>(value.get_sint()));
 		break;
-	case uint:
+	case constant_value_kind::uint:
 		out += 'u';
 		out += bz::format("{}", value.get_uint());
 		break;
-	case float32:
+	case constant_value_kind::float32:
 		out += 'f';
 		out += bz::format("{:08x}", bit_cast<uint32_t>(value.get_float32()));
 		break;
-	case float64:
+	case constant_value_kind::float64:
 		out += 'd';
 		out += bz::format("{:016x}", bit_cast<uint64_t>(value.get_float64()));
 		break;
-	case u8char:
+	case constant_value_kind::u8char:
 		out += 'c';
 		out += bz::format("{}", bit_cast<uint32_t>(value.get_u8char()));
 		break;
-	case string:
+	case constant_value_kind::string:
 	{
 		auto const str = value.get_string();
 		out += 's';
@@ -210,17 +318,17 @@ void constant_value_storage::encode_for_symbol_name(bz::u8string &out, constant_
 		out += str;
 		break;
 	}
-	case boolean:
+	case constant_value_kind::boolean:
 		out += 'b';
 		out += value.get_boolean() ? '1' : '0';
 		break;
-	case null:
+	case constant_value_kind::null:
 		out += 'n';
 		break;
-	case void_:
+	case constant_value_kind::void_:
 		out += 'v';
 		break;
-	case enum_:
+	case constant_value_kind::enum_:
 	{
 		auto const [decl, enum_value] = value.get_enum();
 		out += 'e';
@@ -245,31 +353,31 @@ void constant_value_storage::encode_for_symbol_name(bz::u8string &out, constant_
 		}
 		break;
 	}
-	case array:
+	case constant_value_kind::array:
 		out += 'A';
 		encode_array_like(out, value.get_array());
 		break;
-	case sint_array:
+	case constant_value_kind::sint_array:
 		out += 'I';
 		encode_array_like(out, value.get_sint_array());
 		break;
-	case uint_array:
+	case constant_value_kind::uint_array:
 		out += 'U';
 		encode_array_like(out, value.get_uint_array());
 		break;
-	case float32_array:
+	case constant_value_kind::float32_array:
 		out += 'G';
 		encode_array_like(out, value.get_float32_array());
 		break;
-	case float64_array:
+	case constant_value_kind::float64_array:
 		out += 'D';
 		encode_array_like(out, value.get_float64_array());
 		break;
-	case tuple:
+	case constant_value_kind::tuple:
 		out += 'T';
 		encode_array_like(out, value.get_tuple());
 		break;
-	case function:
+	case constant_value_kind::function:
 	{
 		auto const body = value.get_function();
 		auto const func_symbol = body->symbol_name.as_string_view();
@@ -279,7 +387,7 @@ void constant_value_storage::encode_for_symbol_name(bz::u8string &out, constant_
 		out += func_symbol;
 		break;
 	}
-	case type:
+	case constant_value_kind::type:
 	{
 		auto const symbol = value.get_type().get_symbol_name();
 		out += 't';
@@ -288,7 +396,7 @@ void constant_value_storage::encode_for_symbol_name(bz::u8string &out, constant_
 		out += symbol;
 		break;
 	}
-	case aggregate:
+	case constant_value_kind::aggregate:
 		out += 'a';
 		encode_array_like(out, value.get_aggregate());
 		break;
@@ -590,7 +698,7 @@ bz::u8string constant_value_storage::decode_from_symbol_name(bz::u8string_view::
 	}
 }
 
-bool operator == (constant_value_storage const &lhs, constant_value_storage const &rhs) noexcept
+bool operator == (constant_value const &lhs, constant_value const &rhs) noexcept
 {
 	if (lhs.kind() != rhs.kind())
 	{
@@ -599,56 +707,66 @@ bool operator == (constant_value_storage const &lhs, constant_value_storage cons
 	switch (lhs.kind())
 	{
 	static_assert(constant_value_storage::variant_count == 19);
-	case constant_value_storage::sint:
+	case constant_value_kind::sint:
 		return lhs.get_sint() == rhs.get_sint();
-	case constant_value_storage::uint:
+	case constant_value_kind::uint:
 		return lhs.get_uint() == rhs.get_uint();
-	case constant_value_storage::float32:
+	case constant_value_kind::float32:
 		return lhs.get_float32() == rhs.get_float32();
-	case constant_value_storage::float64:
+	case constant_value_kind::float64:
 		return lhs.get_float64() == rhs.get_float64();
-	case constant_value_storage::u8char:
+	case constant_value_kind::u8char:
 		return lhs.get_u8char() == rhs.get_u8char();
-	case constant_value_storage::string:
+	case constant_value_kind::string:
 		return lhs.get_string() == rhs.get_string();
-	case constant_value_storage::boolean:
+	case constant_value_kind::boolean:
 		return lhs.get_boolean() == rhs.get_boolean();
-	case constant_value_storage::null:
+	case constant_value_kind::null:
 		return true;
-	case constant_value_storage::void_:
+	case constant_value_kind::void_:
 		return true;
-	case constant_value_storage::enum_:
+	case constant_value_kind::enum_:
 	{
 		auto const [lhs_decl, lhs_value] = lhs.get_enum();
 		auto const [rhs_decl, rhs_value] = rhs.get_enum();
 		return lhs_decl == rhs_decl && lhs_value == rhs_value;
 	}
-	case constant_value_storage::array:
+	case constant_value_kind::array:
 		return lhs.get_array() == rhs.get_array();
-	case constant_value_storage::sint_array:
+	case constant_value_kind::sint_array:
 		return lhs.get_sint_array() == rhs.get_sint_array();
-	case constant_value_storage::uint_array:
+	case constant_value_kind::uint_array:
 		return lhs.get_uint_array() == rhs.get_uint_array();
-	case constant_value_storage::float32_array:
+	case constant_value_kind::float32_array:
 		return lhs.get_float32_array() == rhs.get_float32_array();
-	case constant_value_storage::float64_array:
+	case constant_value_kind::float64_array:
 		return lhs.get_float64_array() == rhs.get_float64_array();
-	case constant_value_storage::tuple:
+	case constant_value_kind::tuple:
 		return lhs.get_tuple() == rhs.get_tuple();
-	case constant_value_storage::function:
+	case constant_value_kind::function:
 		return lhs.get_function() == rhs.get_function();
-	case constant_value_storage::type:
+	case constant_value_kind::type:
 		return lhs.get_type() == rhs.get_type();
-	case constant_value_storage::aggregate:
+	case constant_value_kind::aggregate:
 		return lhs.get_aggregate() == rhs.get_aggregate();
 	default:
 		return false;
 	}
 }
 
-bool operator != (constant_value_storage const &lhs, constant_value_storage const &rhs) noexcept
+bool operator != (constant_value const &lhs, constant_value const &rhs) noexcept
 {
 	return !(lhs == rhs);
+}
+
+bool operator == (constant_value_storage const &lhs, constant_value_storage const &rhs) noexcept
+{
+	return lhs.kind() == rhs.kind() && lhs.as_constant_value() == rhs.as_constant_value();
+}
+
+bool operator != (constant_value_storage const &lhs, constant_value_storage const &rhs) noexcept
+{
+	return lhs.kind() != rhs.kind() || lhs.as_constant_value() != rhs.as_constant_value();
 }
 
 } // namespace ast

--- a/src/ast/constant_value.h
+++ b/src/ast/constant_value.h
@@ -399,10 +399,13 @@ struct constant_value_storage : constant_value_storage_base_t
 
 	constant_value as_constant_value(void) const;
 
-	operator constant_value (void) const
+	operator constant_value (void) const &
 	{
 		return this->as_constant_value();
 	}
+
+	operator constant_value (void) && = delete;
+	operator constant_value (void) const && = delete;
 
 	static constant_value_storage get_void(void)
 	{ return constant_value_storage(internal::void_t{}); }

--- a/src/ast/constant_value.h
+++ b/src/ast/constant_value.h
@@ -104,118 +104,142 @@ struct constant_value : constant_value_base_t
 	using base_t = constant_value_base_t;
 	using base_t::operator =;
 
+	template<constant_value_kind kind>
+	decltype(auto) get(void)
+	{
+		return this->base_t::get<static_cast<uint64_t>(kind)>();
+	}
+
+	template<constant_value_kind kind>
+	decltype(auto) get(void) const
+	{
+		return this->base_t::get<static_cast<uint64_t>(kind)>();
+	}
+
+	template<constant_value_kind kind>
+	bool is(void) const
+	{
+		return this->base_t::is<static_cast<uint64_t>(kind)>();
+	}
+
+	template<constant_value_kind kind, typename ...Args>
+	decltype(auto) emplace(Args &&...args)
+	{
+		return this->base_t::emplace<static_cast<uint64_t>(kind)>(std::forward<Args>(args)...);
+	}
+
 	constant_value_kind kind(void) const noexcept
 	{ return static_cast<constant_value_kind>(this->base_t::index()); }
 
 
 	bool is_sint(void) const noexcept
-	{ return this->is<static_cast<uint64_t>(constant_value_kind::sint)>(); }
+	{ return this->is<constant_value_kind::sint>(); }
 
 	bool is_uint(void) const noexcept
-	{ return this->is<static_cast<uint64_t>(constant_value_kind::uint)>(); }
+	{ return this->is<constant_value_kind::uint>(); }
 
 	bool is_float32(void) const noexcept
-	{ return this->is<static_cast<uint64_t>(constant_value_kind::float32)>(); }
+	{ return this->is<constant_value_kind::float32>(); }
 
 	bool is_float64(void) const noexcept
-	{ return this->is<static_cast<uint64_t>(constant_value_kind::float64)>(); }
+	{ return this->is<constant_value_kind::float64>(); }
 
 	bool is_u8char(void) const noexcept
-	{ return this->is<static_cast<uint64_t>(constant_value_kind::u8char)>(); }
+	{ return this->is<constant_value_kind::u8char>(); }
 
 	bool is_string(void) const noexcept
-	{ return this->is<static_cast<uint64_t>(constant_value_kind::string)>(); }
+	{ return this->is<constant_value_kind::string>(); }
 
 	bool is_boolean(void) const noexcept
-	{ return this->is<static_cast<uint64_t>(constant_value_kind::boolean)>(); }
+	{ return this->is<constant_value_kind::boolean>(); }
 
 	bool is_null_constant(void) const noexcept
-	{ return this->is<static_cast<uint64_t>(constant_value_kind::null)>(); }
+	{ return this->is<constant_value_kind::null>(); }
 
 	bool is_void(void) const noexcept
-	{ return this->is<static_cast<uint64_t>(constant_value_kind::void_)>(); }
+	{ return this->is<constant_value_kind::void_>(); }
 
 	bool is_enum(void) const noexcept
-	{ return this->is<static_cast<uint64_t>(constant_value_kind::enum_)>(); }
+	{ return this->is<constant_value_kind::enum_>(); }
 
 	bool is_array(void) const noexcept
-	{ return this->is<static_cast<uint64_t>(constant_value_kind::array)>(); }
+	{ return this->is<constant_value_kind::array>(); }
 
 	bool is_sint_array(void) const noexcept
-	{ return this->is<static_cast<uint64_t>(constant_value_kind::sint_array)>(); }
+	{ return this->is<constant_value_kind::sint_array>(); }
 
 	bool is_uint_array(void) const noexcept
-	{ return this->is<static_cast<uint64_t>(constant_value_kind::uint_array)>(); }
+	{ return this->is<constant_value_kind::uint_array>(); }
 
 	bool is_float32_array(void) const noexcept
-	{ return this->is<static_cast<uint64_t>(constant_value_kind::float32_array)>(); }
+	{ return this->is<constant_value_kind::float32_array>(); }
 
 	bool is_float64_array(void) const noexcept
-	{ return this->is<static_cast<uint64_t>(constant_value_kind::float64_array)>(); }
+	{ return this->is<constant_value_kind::float64_array>(); }
 
 	bool is_tuple(void) const noexcept
-	{ return this->is<static_cast<uint64_t>(constant_value_kind::tuple)>(); }
+	{ return this->is<constant_value_kind::tuple>(); }
 
 	bool is_function(void) const noexcept
-	{ return this->is<static_cast<uint64_t>(constant_value_kind::function)>(); }
+	{ return this->is<constant_value_kind::function>(); }
 
 	bool is_type(void) const noexcept
-	{ return this->is<static_cast<uint64_t>(constant_value_kind::type)>(); }
+	{ return this->is<constant_value_kind::type>(); }
 
 	bool is_aggregate(void) const noexcept
-	{ return this->is<static_cast<uint64_t>(constant_value_kind::aggregate)>(); }
+	{ return this->is<constant_value_kind::aggregate>(); }
 
 
 	int64_t get_sint(void) const noexcept
-	{ return this->get<static_cast<uint64_t>(constant_value_kind::sint)>(); }
+	{ return this->get<constant_value_kind::sint>(); }
 
 	uint64_t get_uint(void) const noexcept
-	{ return this->get<static_cast<uint64_t>(constant_value_kind::uint)>(); }
+	{ return this->get<constant_value_kind::uint>(); }
 
 	float32_t get_float32(void) const noexcept
-	{ return this->get<static_cast<uint64_t>(constant_value_kind::float32)>(); }
+	{ return this->get<constant_value_kind::float32>(); }
 
 	float64_t get_float64(void) const noexcept
-	{ return this->get<static_cast<uint64_t>(constant_value_kind::float64)>(); }
+	{ return this->get<constant_value_kind::float64>(); }
 
 	bz::u8char get_u8char(void) const noexcept
-	{ return this->get<static_cast<uint64_t>(constant_value_kind::u8char)>(); }
+	{ return this->get<constant_value_kind::u8char>(); }
 
 	bz::u8string_view get_string(void) const noexcept
-	{ return this->get<static_cast<uint64_t>(constant_value_kind::string)>(); }
+	{ return this->get<constant_value_kind::string>(); }
 
 	bool get_boolean(void) const noexcept
-	{ return this->get<static_cast<uint64_t>(constant_value_kind::boolean)>(); }
+	{ return this->get<constant_value_kind::boolean>(); }
 
 	internal::enum_t get_enum(void) const noexcept
-	{ return this->get<static_cast<uint64_t>(constant_value_kind::enum_)>(); }
+	{ return this->get<constant_value_kind::enum_>(); }
 
 	bz::array_view<constant_value_storage const> get_array(void) const noexcept
-	{ return this->get<static_cast<uint64_t>(constant_value_kind::array)>(); }
+	{ return this->get<constant_value_kind::array>(); }
 
 	bz::array_view<int64_t const> get_sint_array(void) const noexcept
-	{ return this->get<static_cast<uint64_t>(constant_value_kind::sint_array)>(); }
+	{ return this->get<constant_value_kind::sint_array>(); }
 
 	bz::array_view<uint64_t const> get_uint_array(void) const noexcept
-	{ return this->get<static_cast<uint64_t>(constant_value_kind::uint_array)>(); }
+	{ return this->get<constant_value_kind::uint_array>(); }
 
 	bz::array_view<float32_t const> get_float32_array(void) const noexcept
-	{ return this->get<static_cast<uint64_t>(constant_value_kind::float32_array)>(); }
+	{ return this->get<constant_value_kind::float32_array>(); }
 
 	bz::array_view<float64_t const> get_float64_array(void) const noexcept
-	{ return this->get<static_cast<uint64_t>(constant_value_kind::float64_array)>(); }
+	{ return this->get<constant_value_kind::float64_array>(); }
 
 	bz::array_view<constant_value_storage const> get_tuple(void) const noexcept
-	{ return this->get<static_cast<uint64_t>(constant_value_kind::tuple)>(); }
+	{ return this->get<constant_value_kind::tuple>(); }
 
 	function_body *get_function(void) const noexcept
-	{ return this->get<static_cast<uint64_t>(constant_value_kind::function)>(); }
+	{ return this->get<constant_value_kind::function>(); }
 
 	typespec_view get_type(void) const noexcept
-	{ return this->get<static_cast<uint64_t>(constant_value_kind::type)>(); }
+	{ return this->get<constant_value_kind::type>(); }
 
 	bz::array_view<constant_value_storage const> get_aggregate(void) const noexcept
-	{ return this->get<static_cast<uint64_t>(constant_value_kind::aggregate)>(); }
+	{ return this->get<constant_value_kind::aggregate>(); }
 
 
 	constant_value(void) = default;

--- a/src/ast/constant_value.h
+++ b/src/ast/constant_value.h
@@ -11,7 +11,7 @@ namespace ast
 
 struct statement_view;
 
-struct constant_value_storage;
+struct constant_value;
 namespace internal
 {
 
@@ -35,50 +35,25 @@ using constant_value_base_t = bz::variant<
 	internal::enum_t,
 
 	// arrays
-	bz::array_view<constant_value_storage const>,
+	bz::array_view<constant_value const>,
 	bz::array_view<int64_t const>,
 	bz::array_view<uint64_t const>,
 	bz::array_view<float32_t const>,
 	bz::array_view<float64_t const>,
 	// tuples
-	bz::array_view<constant_value_storage const>,
+	bz::array_view<constant_value const>,
 
 	function_body *,
 
 	typespec_view,
 
 	// structs
-	bz::array_view<constant_value_storage const>
->;
-
-using constant_value_storage_base_t = bz::variant<
-	int64_t, uint64_t,
-	float32_t, float64_t,
-	bz::u8char, bz::u8string,
-	bool, internal::null_t,
-	internal::void_t,
-	internal::enum_t,
-
-	// arrays
-	arena_vector<constant_value_storage>,
-	arena_vector<int64_t>,
-	arena_vector<uint64_t>,
-	arena_vector<float32_t>,
-	arena_vector<float64_t>,
-	// tuples
-	arena_vector<constant_value_storage>,
-
-	function_body *,
-
-	typespec,
-
-	// structs
-	arena_vector<constant_value_storage>
+	bz::array_view<constant_value const>
 >;
 
 enum class constant_value_kind : uint64_t
 {
-	sint = constant_value_storage_base_t::index_of<int64_t>,
+	sint = constant_value_base_t::index_of<int64_t>,
 	uint,
 	float32,
 	float64,
@@ -214,7 +189,7 @@ struct constant_value : constant_value_base_t
 	internal::enum_t get_enum(void) const noexcept
 	{ return this->get<constant_value_kind::enum_>(); }
 
-	bz::array_view<constant_value_storage const> get_array(void) const noexcept
+	bz::array_view<constant_value const> get_array(void) const noexcept
 	{ return this->get<constant_value_kind::array>(); }
 
 	bz::array_view<int64_t const> get_sint_array(void) const noexcept
@@ -229,7 +204,7 @@ struct constant_value : constant_value_base_t
 	bz::array_view<float64_t const> get_float64_array(void) const noexcept
 	{ return this->get<constant_value_kind::float64_array>(); }
 
-	bz::array_view<constant_value_storage const> get_tuple(void) const noexcept
+	bz::array_view<constant_value const> get_tuple(void) const noexcept
 	{ return this->get<constant_value_kind::tuple>(); }
 
 	function_body *get_function(void) const noexcept
@@ -238,14 +213,23 @@ struct constant_value : constant_value_base_t
 	typespec_view get_type(void) const noexcept
 	{ return this->get<constant_value_kind::type>(); }
 
-	bz::array_view<constant_value_storage const> get_aggregate(void) const noexcept
+	bz::array_view<constant_value const> get_aggregate(void) const noexcept
 	{ return this->get<constant_value_kind::aggregate>(); }
 
 
 	constant_value(void) = default;
 
-	template<typename T, bz::meta::enable_if<!bz::meta::is_same<bz::meta::remove_cv_reference<T>, constant_value_storage>, int> = 0>
-	explicit constant_value(T &&t)
+	template<typename T>
+	explicit constant_value(T &&t) requires(
+		!bz::meta::is_same<bz::meta::remove_cv_reference<T>, constant_value>
+		&& !bz::meta::is_same<bz::meta::remove_cv_reference<T>, bz::u8string>
+		&& !bz::meta::is_same<bz::meta::remove_cv_reference<T>, typespec>
+		&& !bz::meta::is_same<bz::meta::remove_cv_reference<T>, arena_vector<constant_value>>
+		&& !bz::meta::is_same<bz::meta::remove_cv_reference<T>, arena_vector<int64_t>>
+		&& !bz::meta::is_same<bz::meta::remove_cv_reference<T>, arena_vector<uint64_t>>
+		&& !bz::meta::is_same<bz::meta::remove_cv_reference<T>, arena_vector<float32_t>>
+		&& !bz::meta::is_same<bz::meta::remove_cv_reference<T>, arena_vector<float64_t>>
+	)
 		: base_t(std::forward<T>(t))
 	{}
 
@@ -261,7 +245,7 @@ struct constant_value : constant_value_base_t
 	static constant_value get_enum(decl_enum *decl, uint64_t value)
 	{ return constant_value(internal::enum_t{ decl, value }); }
 
-	static void encode_for_symbol_name(bz::u8string &out, constant_value_storage const &value);
+	static void encode_for_symbol_name(bz::u8string &out, constant_value const &value);
 	static bz::u8string decode_from_symbol_name(bz::u8string_view::const_iterator &it, bz::u8string_view::const_iterator end);
 	static bz::u8string decode_from_symbol_name(bz::u8string_view str)
 	{
@@ -271,195 +255,10 @@ struct constant_value : constant_value_base_t
 	}
 };
 
-struct constant_value_storage : constant_value_storage_base_t
-{
-	using base_t = constant_value_storage_base_t;
-	using base_t::operator =;
-
-	template<constant_value_kind kind>
-	decltype(auto) get(void)
-	{
-		return this->base_t::get<static_cast<uint64_t>(kind)>();
-	}
-
-	template<constant_value_kind kind>
-	decltype(auto) get(void) const
-	{
-		return this->base_t::get<static_cast<uint64_t>(kind)>();
-	}
-
-	template<constant_value_kind kind>
-	bool is(void) const
-	{
-		return this->base_t::is<static_cast<uint64_t>(kind)>();
-	}
-
-	template<constant_value_kind kind, typename ...Args>
-	decltype(auto) emplace(Args &&...args)
-	{
-		return this->base_t::emplace<static_cast<uint64_t>(kind)>(std::forward<Args>(args)...);
-	}
-
-	constant_value_kind kind(void) const noexcept
-	{ return static_cast<constant_value_kind>(this->base_t::index()); }
-
-
-	bool is_sint(void) const noexcept
-	{ return this->is<constant_value_kind::sint>(); }
-
-	bool is_uint(void) const noexcept
-	{ return this->is<constant_value_kind::uint>(); }
-
-	bool is_float32(void) const noexcept
-	{ return this->is<constant_value_kind::float32>(); }
-
-	bool is_float64(void) const noexcept
-	{ return this->is<constant_value_kind::float64>(); }
-
-	bool is_u8char(void) const noexcept
-	{ return this->is<constant_value_kind::u8char>(); }
-
-	bool is_string(void) const noexcept
-	{ return this->is<constant_value_kind::string>(); }
-
-	bool is_boolean(void) const noexcept
-	{ return this->is<constant_value_kind::boolean>(); }
-
-	bool is_null_constant(void) const noexcept
-	{ return this->is<constant_value_kind::null>(); }
-
-	bool is_void(void) const noexcept
-	{ return this->is<constant_value_kind::void_>(); }
-
-	bool is_enum(void) const noexcept
-	{ return this->is<constant_value_kind::enum_>(); }
-
-	bool is_array(void) const noexcept
-	{ return this->is<constant_value_kind::array>(); }
-
-	bool is_sint_array(void) const noexcept
-	{ return this->is<constant_value_kind::sint_array>(); }
-
-	bool is_uint_array(void) const noexcept
-	{ return this->is<constant_value_kind::uint_array>(); }
-
-	bool is_float32_array(void) const noexcept
-	{ return this->is<constant_value_kind::float32_array>(); }
-
-	bool is_float64_array(void) const noexcept
-	{ return this->is<constant_value_kind::float64_array>(); }
-
-	bool is_tuple(void) const noexcept
-	{ return this->is<constant_value_kind::tuple>(); }
-
-	bool is_function(void) const noexcept
-	{ return this->is<constant_value_kind::function>(); }
-
-	bool is_type(void) const noexcept
-	{ return this->is<constant_value_kind::type>(); }
-
-	bool is_aggregate(void) const noexcept
-	{ return this->is<constant_value_kind::aggregate>(); }
-
-
-	int64_t get_sint(void) const noexcept
-	{ return this->get<constant_value_kind::sint>(); }
-
-	uint64_t get_uint(void) const noexcept
-	{ return this->get<constant_value_kind::uint>(); }
-
-	float32_t get_float32(void) const noexcept
-	{ return this->get<constant_value_kind::float32>(); }
-
-	float64_t get_float64(void) const noexcept
-	{ return this->get<constant_value_kind::float64>(); }
-
-	bz::u8char get_u8char(void) const noexcept
-	{ return this->get<constant_value_kind::u8char>(); }
-
-	bz::u8string_view get_string(void) const noexcept
-	{ return this->get<constant_value_kind::string>(); }
-
-	bool get_boolean(void) const noexcept
-	{ return this->get<constant_value_kind::boolean>(); }
-
-	internal::enum_t get_enum(void) const noexcept
-	{ return this->get<constant_value_kind::enum_>(); }
-
-	bz::array_view<constant_value_storage const> get_array(void) const noexcept
-	{ return this->get<constant_value_kind::array>(); }
-
-	bz::array_view<int64_t const> get_sint_array(void) const noexcept
-	{ return this->get<constant_value_kind::sint_array>(); }
-
-	bz::array_view<uint64_t const> get_uint_array(void) const noexcept
-	{ return this->get<constant_value_kind::uint_array>(); }
-
-	bz::array_view<float32_t const> get_float32_array(void) const noexcept
-	{ return this->get<constant_value_kind::float32_array>(); }
-
-	bz::array_view<float64_t const> get_float64_array(void) const noexcept
-	{ return this->get<constant_value_kind::float64_array>(); }
-
-	bz::array_view<constant_value_storage const> get_tuple(void) const noexcept
-	{ return this->get<constant_value_kind::tuple>(); }
-
-	function_body *get_function(void) const noexcept
-	{ return this->get<constant_value_kind::function>(); }
-
-	typespec_view get_type(void) const noexcept
-	{ return this->get<constant_value_kind::type>(); }
-
-	bz::array_view<constant_value_storage const> get_aggregate(void) const noexcept
-	{ return this->get<constant_value_kind::aggregate>(); }
-
-
-	constant_value_storage(void) = default;
-
-	template<typename T, bz::meta::enable_if<!bz::meta::is_same<bz::meta::remove_cv_reference<T>, constant_value_storage>, int> = 0>
-	explicit constant_value_storage(T &&t)
-		: base_t(std::forward<T>(t))
-	{}
-
-	constant_value as_constant_value(void) const;
-
-	operator constant_value (void) const &
-	{
-		return this->as_constant_value();
-	}
-
-	operator constant_value (void) && = delete;
-	operator constant_value (void) const && = delete;
-
-	static constant_value_storage get_void(void)
-	{ return constant_value_storage(internal::void_t{}); }
-
-	static constant_value_storage get_null(void)
-	{ return constant_value_storage(internal::null_t{}); }
-
-	static constant_value_storage get_enum(decl_enum *decl, int64_t value)
-	{ return constant_value_storage(internal::enum_t{ decl, bit_cast<uint64_t>(value) }); }
-
-	static constant_value_storage get_enum(decl_enum *decl, uint64_t value)
-	{ return constant_value_storage(internal::enum_t{ decl, value }); }
-
-	static void encode_for_symbol_name(bz::u8string &out, constant_value_storage const &value);
-	static bz::u8string decode_from_symbol_name(bz::u8string_view::const_iterator &it, bz::u8string_view::const_iterator end);
-	static bz::u8string decode_from_symbol_name(bz::u8string_view str)
-	{
-		auto it = str.begin();
-		auto const end = str.end();
-		return decode_from_symbol_name(it, end);
-	}
-};
-
-bz::u8string get_value_string(constant_value_storage const &value);
+bz::u8string get_value_string(constant_value const &value);
 
 bool operator == (constant_value const &lhs, constant_value const &rhs) noexcept;
 bool operator != (constant_value const &lhs, constant_value const &rhs) noexcept;
-
-bool operator == (constant_value_storage const &lhs, constant_value_storage const &rhs) noexcept;
-bool operator != (constant_value_storage const &lhs, constant_value_storage const &rhs) noexcept;
 
 } // namespace ast
 

--- a/src/ast/expression.cpp
+++ b/src/ast/expression.cpp
@@ -343,13 +343,13 @@ bool expression::is_typename(void) const noexcept
 typespec &expression::get_typename(void) noexcept
 {
 	bz_assert(this->is_typename());
-	return this->get_constant_value().get<constant_value::type>();
+	return this->get_constant_value().get<constant_value_storage::type>();
 }
 
 typespec const &expression::get_typename(void) const noexcept
 {
 	bz_assert(this->is_typename());
-	return this->get_constant_value().get<constant_value::type>();
+	return this->get_constant_value().get<constant_value_storage::type>();
 }
 
 bool expression::is_tuple(void) const noexcept
@@ -408,7 +408,7 @@ bool expression::is_integer_literal(void) const noexcept
 	return is_expr_kind_helper(*this, expression_type_kind::integer_literal);
 }
 
-constant_value &expression::get_integer_literal_value(void) noexcept
+constant_value_storage &expression::get_integer_literal_value(void) noexcept
 {
 	bz_assert(this->is_integer_literal());
 	auto &literal_expr = get_expr_kind<expr_integer_literal, false>(*this);
@@ -416,7 +416,7 @@ constant_value &expression::get_integer_literal_value(void) noexcept
 	return literal_expr.get_constant_value();
 }
 
-constant_value const &expression::get_integer_literal_value(void) const noexcept
+constant_value_storage const &expression::get_integer_literal_value(void) const noexcept
 {
 	bz_assert(this->is_integer_literal());
 	auto const &literal_expr = get_expr_kind<expr_integer_literal, false>(*this);
@@ -424,7 +424,7 @@ constant_value const &expression::get_integer_literal_value(void) const noexcept
 	return literal_expr.get_constant_value();
 }
 
-std::pair<literal_kind, constant_value const &> expression::get_integer_literal_kind_and_value(void) const noexcept
+std::pair<literal_kind, constant_value_storage const &> expression::get_integer_literal_kind_and_value(void) const noexcept
 {
 	bz_assert(this->is_integer_literal());
 	auto const &literal_expr = get_expr_kind<expr_integer_literal, false>(*this);
@@ -570,13 +570,13 @@ constant_expression const &expression::get_constant(void) const noexcept
 	return this->get<constant_expression>();
 }
 
-constant_value &expression::get_constant_value(void) noexcept
+constant_value_storage &expression::get_constant_value(void) noexcept
 {
 	bz_assert(this->is_constant());
 	return this->get<constant_expression>().value;
 }
 
-constant_value const &expression::get_constant_value(void) const noexcept
+constant_value_storage const &expression::get_constant_value(void) const noexcept
 {
 	bz_assert(this->is_constant());
 	return this->get<constant_expression>().value;

--- a/src/ast/expression.cpp
+++ b/src/ast/expression.cpp
@@ -340,16 +340,10 @@ bool expression::is_typename(void) const noexcept
 		&& (const_expr->kind == expression_type_kind::type_name || const_expr->value.is_type());
 }
 
-typespec &expression::get_typename(void) noexcept
+typespec_view expression::get_typename(void) const noexcept
 {
 	bz_assert(this->is_typename());
-	return this->get_constant_value().get<constant_value_kind::type>();
-}
-
-typespec const &expression::get_typename(void) const noexcept
-{
-	bz_assert(this->is_typename());
-	return this->get_constant_value().get<constant_value_kind::type>();
+	return this->get_constant_value().get_type();
 }
 
 bool expression::is_tuple(void) const noexcept
@@ -408,7 +402,7 @@ bool expression::is_integer_literal(void) const noexcept
 	return is_expr_kind_helper(*this, expression_type_kind::integer_literal);
 }
 
-constant_value_storage &expression::get_integer_literal_value(void) noexcept
+constant_value &expression::get_integer_literal_value(void) noexcept
 {
 	bz_assert(this->is_integer_literal());
 	auto &literal_expr = get_expr_kind<expr_integer_literal, false>(*this);
@@ -416,7 +410,7 @@ constant_value_storage &expression::get_integer_literal_value(void) noexcept
 	return literal_expr.get_constant_value();
 }
 
-constant_value_storage const &expression::get_integer_literal_value(void) const noexcept
+constant_value const &expression::get_integer_literal_value(void) const noexcept
 {
 	bz_assert(this->is_integer_literal());
 	auto const &literal_expr = get_expr_kind<expr_integer_literal, false>(*this);
@@ -424,7 +418,7 @@ constant_value_storage const &expression::get_integer_literal_value(void) const 
 	return literal_expr.get_constant_value();
 }
 
-std::pair<literal_kind, constant_value_storage const &> expression::get_integer_literal_kind_and_value(void) const noexcept
+std::pair<literal_kind, constant_value const &> expression::get_integer_literal_kind_and_value(void) const noexcept
 {
 	bz_assert(this->is_integer_literal());
 	auto const &literal_expr = get_expr_kind<expr_integer_literal, false>(*this);
@@ -481,7 +475,7 @@ bool expression::is_generic_type(void) const noexcept
 		return false;
 	}
 
-	auto const type = this->get_typename().as_typespec_view();
+	auto const type = this->get_typename();
 	return type.is<ts_base_type>() && type.get<ts_base_type>().info->is_generic();
 }
 
@@ -570,13 +564,13 @@ constant_expression const &expression::get_constant(void) const noexcept
 	return this->get<constant_expression>();
 }
 
-constant_value_storage &expression::get_constant_value(void) noexcept
+constant_value &expression::get_constant_value(void) noexcept
 {
 	bz_assert(this->is_constant());
 	return this->get<constant_expression>().value;
 }
 
-constant_value_storage const &expression::get_constant_value(void) const noexcept
+constant_value const &expression::get_constant_value(void) const noexcept
 {
 	bz_assert(this->is_constant());
 	return this->get<constant_expression>().value;

--- a/src/ast/expression.cpp
+++ b/src/ast/expression.cpp
@@ -343,13 +343,13 @@ bool expression::is_typename(void) const noexcept
 typespec &expression::get_typename(void) noexcept
 {
 	bz_assert(this->is_typename());
-	return this->get_constant_value().get<constant_value_storage::type>();
+	return this->get_constant_value().get<constant_value_kind::type>();
 }
 
 typespec const &expression::get_typename(void) const noexcept
 {
 	bz_assert(this->is_typename());
-	return this->get_constant_value().get<constant_value_storage::type>();
+	return this->get_constant_value().get<constant_value_kind::type>();
 }
 
 bool expression::is_tuple(void) const noexcept

--- a/src/ast/expression.h
+++ b/src/ast/expression.h
@@ -338,7 +338,7 @@ struct constant_expression
 {
 	expression_type_kind kind;
 	typespec             type;
-	constant_value       value;
+	constant_value_storage       value;
 	expr_t               expr;
 };
 
@@ -457,9 +457,9 @@ struct expression : bz::variant<
 	expr_switch const &get_switch_expr(void) const noexcept;
 
 	bool is_integer_literal(void) const noexcept;
-	constant_value &get_integer_literal_value(void) noexcept;
-	constant_value const &get_integer_literal_value(void) const noexcept;
-	std::pair<literal_kind, constant_value const &> get_integer_literal_kind_and_value(void) const noexcept;
+	constant_value_storage &get_integer_literal_value(void) noexcept;
+	constant_value_storage const &get_integer_literal_value(void) const noexcept;
+	std::pair<literal_kind, constant_value_storage const &> get_integer_literal_kind_and_value(void) const noexcept;
 
 	bool is_enum_literal(void) const noexcept;
 	expr_enum_literal &get_enum_literal(void) noexcept;
@@ -482,8 +482,8 @@ struct expression : bz::variant<
 	bool is_constant(void) const noexcept;
 	constant_expression &get_constant(void) noexcept;
 	constant_expression const &get_constant(void) const noexcept;
-	constant_value &get_constant_value(void) noexcept;
-	constant_value const &get_constant_value(void) const noexcept;
+	constant_value_storage &get_constant_value(void) noexcept;
+	constant_value_storage const &get_constant_value(void) const noexcept;
 
 	bool is_dynamic(void) const noexcept;
 	dynamic_expression &get_dynamic(void) noexcept;
@@ -1835,7 +1835,7 @@ inline expression type_as_expression(lex::src_tokens const &src_tokens, typespec
 		src_tokens,
 		expression_type_kind::type_name,
 		make_typename_typespec(nullptr),
-		constant_value(std::move(type)),
+		constant_value_storage(std::move(type)),
 		expr_t{}
 	);
 }

--- a/src/ast/expression.h
+++ b/src/ast/expression.h
@@ -338,7 +338,7 @@ struct constant_expression
 {
 	expression_type_kind kind;
 	typespec             type;
-	constant_value_storage       value;
+	constant_value       value;
 	expr_t               expr;
 };
 
@@ -441,8 +441,7 @@ struct expression : bz::variant<
 	expr_function_overload_set const &get_function_overload_set(void) const noexcept;
 
 	bool is_typename(void) const noexcept;
-	typespec &get_typename(void) noexcept;
-	typespec const &get_typename(void) const noexcept;
+	typespec_view get_typename(void) const noexcept;
 
 	bool is_tuple(void) const noexcept;
 	expr_tuple &get_tuple(void) noexcept;
@@ -457,9 +456,9 @@ struct expression : bz::variant<
 	expr_switch const &get_switch_expr(void) const noexcept;
 
 	bool is_integer_literal(void) const noexcept;
-	constant_value_storage &get_integer_literal_value(void) noexcept;
-	constant_value_storage const &get_integer_literal_value(void) const noexcept;
-	std::pair<literal_kind, constant_value_storage const &> get_integer_literal_kind_and_value(void) const noexcept;
+	constant_value &get_integer_literal_value(void) noexcept;
+	constant_value const &get_integer_literal_value(void) const noexcept;
+	std::pair<literal_kind, constant_value const &> get_integer_literal_kind_and_value(void) const noexcept;
 
 	bool is_enum_literal(void) const noexcept;
 	expr_enum_literal &get_enum_literal(void) noexcept;
@@ -482,8 +481,8 @@ struct expression : bz::variant<
 	bool is_constant(void) const noexcept;
 	constant_expression &get_constant(void) noexcept;
 	constant_expression const &get_constant(void) const noexcept;
-	constant_value_storage &get_constant_value(void) noexcept;
-	constant_value_storage const &get_constant_value(void) const noexcept;
+	constant_value &get_constant_value(void) noexcept;
+	constant_value const &get_constant_value(void) const noexcept;
 
 	bool is_dynamic(void) const noexcept;
 	dynamic_expression &get_dynamic(void) noexcept;
@@ -1827,18 +1826,6 @@ def_make_unresolved_fn(unresolved_expr_t, expr_unresolved_integer_range_to)
 def_make_unresolved_fn(unresolved_expr_t, expr_unresolved_integer_range_to_inclusive)
 
 #undef def_make_unresolved_fn
-
-
-inline expression type_as_expression(lex::src_tokens const &src_tokens, typespec type)
-{
-	return make_constant_expression(
-		src_tokens,
-		expression_type_kind::type_name,
-		make_typename_typespec(nullptr),
-		constant_value_storage(std::move(type)),
-		expr_t{}
-	);
-}
 
 } // namespace ast
 

--- a/src/ast/statement.cpp
+++ b/src/ast/statement.cpp
@@ -106,7 +106,7 @@ bz::u8string function_body::get_symbol_name(void) const
 			{
 				bz_assert(p.init_expr.is_constant());
 				symbol_name += '.';
-				constant_value::encode_for_symbol_name(symbol_name, p.init_expr.get_constant_value());
+				constant_value_storage::encode_for_symbol_name(symbol_name, p.init_expr.get_constant_value());
 			}
 		}
 		return symbol_name;
@@ -127,7 +127,7 @@ bz::u8string function_body::get_symbol_name(void) const
 			{
 				bz_assert(p.init_expr.is_constant());
 				symbol_name += '.';
-				constant_value::encode_for_symbol_name(symbol_name, p.init_expr.get_constant_value());
+				constant_value_storage::encode_for_symbol_name(symbol_name, p.init_expr.get_constant_value());
 			}
 		}
 		symbol_name += '.';
@@ -300,7 +300,7 @@ bz::u8string function_body::decode_symbol_name(
 			bz_assert(*it == '.');
 			++it;
 			result += " = ";
-			result += constant_value::decode_from_symbol_name(it, end);
+			result += constant_value_storage::decode_from_symbol_name(it, end);
 		}
 	}
 

--- a/src/ast/statement.cpp
+++ b/src/ast/statement.cpp
@@ -106,7 +106,7 @@ bz::u8string function_body::get_symbol_name(void) const
 			{
 				bz_assert(p.init_expr.is_constant());
 				symbol_name += '.';
-				constant_value_storage::encode_for_symbol_name(symbol_name, p.init_expr.get_constant_value());
+				constant_value::encode_for_symbol_name(symbol_name, p.init_expr.get_constant_value());
 			}
 		}
 		return symbol_name;
@@ -127,7 +127,7 @@ bz::u8string function_body::get_symbol_name(void) const
 			{
 				bz_assert(p.init_expr.is_constant());
 				symbol_name += '.';
-				constant_value_storage::encode_for_symbol_name(symbol_name, p.init_expr.get_constant_value());
+				constant_value::encode_for_symbol_name(symbol_name, p.init_expr.get_constant_value());
 			}
 		}
 		symbol_name += '.';
@@ -300,7 +300,7 @@ bz::u8string function_body::decode_symbol_name(
 			bz_assert(*it == '.');
 			++it;
 			result += " = ";
-			result += constant_value_storage::decode_from_symbol_name(it, end);
+			result += constant_value::decode_from_symbol_name(it, end);
 		}
 	}
 
@@ -345,13 +345,13 @@ type_info::decl_operator_ptr type_info::make_default_op_assign(lex::src_tokens c
 	result->body.params.emplace_back(
 		lex::src_tokens{},
 		lex::token_range{},
-		var_id_and_type(identifier{}, type_as_expression(src_tokens, std::move(lhs_t))),
+		var_id_and_type(identifier{}, std::move(lhs_t)),
 		enclosing_scope_t{}
 	);
 	result->body.params.emplace_back(
 		lex::src_tokens{},
 		lex::token_range{},
-		var_id_and_type(identifier{}, type_as_expression(src_tokens, std::move(rhs_t))),
+		var_id_and_type(identifier{}, std::move(rhs_t)),
 		enclosing_scope_t{}
 	);
 	result->body.return_type = std::move(ret_t);
@@ -384,13 +384,13 @@ type_info::decl_operator_ptr type_info::make_default_op_move_assign(lex::src_tok
 	result->body.params.emplace_back(
 		lex::src_tokens{},
 		lex::token_range{},
-		var_id_and_type(identifier{}, type_as_expression(src_tokens, std::move(lhs_t))),
+		var_id_and_type(identifier{}, std::move(lhs_t)),
 		enclosing_scope_t{}
 	);
 	result->body.params.emplace_back(
 		lex::src_tokens{},
 		lex::token_range{},
-		var_id_and_type(identifier{}, type_as_expression(src_tokens, std::move(rhs_t))),
+		var_id_and_type(identifier{}, std::move(rhs_t)),
 		enclosing_scope_t{}
 	);
 	result->body.return_type = std::move(ret_t);
@@ -413,7 +413,7 @@ type_info::decl_function_ptr type_info::make_default_copy_constructor(lex::src_t
 	result->body.params.emplace_back(
 		lex::src_tokens{},
 		lex::token_range{},
-		var_id_and_type(identifier{}, type_as_expression(src_tokens, std::move(param_t))),
+		var_id_and_type(identifier{}, std::move(param_t)),
 		enclosing_scope_t{}
 	);
 	result->body.return_type = std::move(ret_t);
@@ -437,7 +437,7 @@ type_info::decl_function_ptr type_info::make_default_move_constructor(lex::src_t
 	result->body.params.emplace_back(
 		lex::src_tokens{},
 		lex::token_range{},
-		var_id_and_type(identifier{}, type_as_expression(src_tokens, std::move(param_t))),
+		var_id_and_type(identifier{}, std::move(param_t)),
 		enclosing_scope_t{}
 	);
 	result->body.return_type = std::move(ret_t);
@@ -666,13 +666,13 @@ decl_enum::decl_operator_ptr decl_enum::make_default_op_assign(lex::src_tokens c
 	result->body.params.emplace_back(
 		lex::src_tokens{},
 		lex::token_range{},
-		var_id_and_type(identifier{}, type_as_expression(src_tokens, std::move(lhs_t))),
+		var_id_and_type(identifier{}, std::move(lhs_t)),
 		enclosing_scope_t{}
 	);
 	result->body.params.emplace_back(
 		lex::src_tokens{},
 		lex::token_range{},
-		var_id_and_type(identifier{}, type_as_expression(src_tokens, std::move(rhs_t))),
+		var_id_and_type(identifier{}, std::move(rhs_t)),
 		enclosing_scope_t{}
 	);
 	result->body.return_type = std::move(ret_t);
@@ -699,13 +699,13 @@ decl_enum::decl_operator_ptr decl_enum::make_default_compare_op(
 	result->body.params.emplace_back(
 		lex::src_tokens{},
 		lex::token_range{},
-		var_id_and_type(identifier{}, type_as_expression(src_tokens, std::move(lhs_t))),
+		var_id_and_type(identifier{}, std::move(lhs_t)),
 		enclosing_scope_t{}
 	);
 	result->body.params.emplace_back(
 		lex::src_tokens{},
 		lex::token_range{},
-		var_id_and_type(identifier{}, type_as_expression(src_tokens, std::move(rhs_t))),
+		var_id_and_type(identifier{}, std::move(rhs_t)),
 		enclosing_scope_t{}
 	);
 	result->body.return_type = std::move(result_type);

--- a/src/ast/statement.h
+++ b/src/ast/statement.h
@@ -184,18 +184,22 @@ struct stmt_static_assert
 struct var_id_and_type
 {
 	identifier id;
-	expression var_type;
+	expression var_type_expr;
+	typespec var_type;
 
-	var_id_and_type(void)
-		: id(), var_type(type_as_expression(lex::src_tokens(), typespec()))
-	{}
+	var_id_and_type(void) = default;
 
-	var_id_and_type(identifier _id, expression _var_type)
+	var_id_and_type(identifier _id, expression _var_type_expr)
+		: id(std::move(_id)), var_type_expr(std::move(_var_type_expr))
+	{
+		if (this->var_type_expr.is_typename())
+		{
+			this->var_type = this->var_type_expr.get_typename();
+		}
+	}
+
+	var_id_and_type(identifier _id, typespec _var_type)
 		: id(std::move(_id)), var_type(std::move(_var_type))
-	{}
-
-	var_id_and_type(identifier _id)
-		: id(std::move(_id)), var_type(type_as_expression(lex::src_tokens::from_range(this->id.tokens), typespec()))
 	{}
 };
 
@@ -383,26 +387,17 @@ struct decl_variable
 
 	typespec &get_type(void)
 	{
-		bz_assert(this->id_and_type.var_type.is_typename());
-		return this->id_and_type.var_type.get_typename();
+		return this->id_and_type.var_type;
 	}
 
 	typespec const &get_type(void) const
 	{
-		bz_assert(this->id_and_type.var_type.is_typename());
-		return this->id_and_type.var_type.get_typename();
+		return this->id_and_type.var_type;
 	}
 
 	void clear_type(void)
 	{
-		if (this->id_and_type.var_type.is_typename())
-		{
-			this->id_and_type.var_type.get_typename().clear();
-		}
-		else
-		{
-			this->id_and_type.var_type = type_as_expression(this->id_and_type.var_type.src_tokens, typespec());
-		}
+		this->id_and_type.var_type.clear();
 		for (auto &decl : this->tuple_decls)
 		{
 			decl.clear_type();

--- a/src/codegen/llvm_latest/emit_bitcode.cpp
+++ b/src/codegen/llvm_latest/emit_bitcode.cpp
@@ -11,7 +11,7 @@ namespace codegen::llvm_latest
 constexpr size_t array_loop_threshold = 16;
 
 static llvm::Constant *get_value(
-	ast::constant_value_storage const &value,
+	ast::constant_value const &value,
 	ast::typespec_view type,
 	ast::constant_expression const *const_expr,
 	bitcode_context &context
@@ -250,8 +250,12 @@ static void emit_panic_call(
 	ast::arena_vector<is_byval_and_type_pair> params_is_byval = {};
 	params.reserve(2);
 
+	auto const panic_string = bz::format(
+		"panic called from {}: {}",
+		context.global_ctx.get_location_string(src_tokens.pivot), message
+	);
 	auto const param_val = get_value(
-		ast::constant_value_storage(bz::format("panic called from {}: {}", context.global_ctx.get_location_string(src_tokens.pivot), message)),
+		ast::constant_value(panic_string.as_string_view()),
 		panic_handler_func_body->params[0].get_type(),
 		nullptr,
 		context
@@ -6778,11 +6782,11 @@ static val_ptr emit_bitcode(
 	return context.get_value_reference(bitcode_value_reference.index);
 }
 
-static bool is_zero_value(ast::constant_value_storage const &value)
+static bool is_zero_value(ast::constant_value const &value)
 {
 	switch (value.kind())
 	{
-	static_assert(ast::constant_value_storage::variant_count == 19);
+	static_assert(ast::constant_value::variant_count == 19);
 	case ast::constant_value_kind::sint:
 		return value.get_sint() == 0;
 	case ast::constant_value_kind::uint:
@@ -6827,7 +6831,7 @@ static bool is_zero_value(ast::constant_value_storage const &value)
 }
 
 static llvm::Constant *get_array_value(
-	bz::array_view<ast::constant_value_storage const> values,
+	bz::array_view<ast::constant_value const> values,
 	ast::ts_array const &array_type,
 	llvm::ArrayType *type,
 	bitcode_context &context
@@ -7023,7 +7027,7 @@ static llvm::Constant *get_float64_array_value(
 }
 
 static llvm::Constant *get_value_helper(
-	ast::constant_value_storage const &value,
+	ast::constant_value const &value,
 	ast::typespec_view type,
 	ast::constant_expression const *const_expr,
 	bitcode_context &context
@@ -7031,7 +7035,7 @@ static llvm::Constant *get_value_helper(
 {
 	switch (value.kind())
 	{
-	static_assert(ast::constant_value_storage::variant_count == 19);
+	static_assert(ast::constant_value::variant_count == 19);
 	case ast::constant_value_kind::sint:
 		bz_assert(!type.is_empty());
 		return llvm::ConstantInt::get(
@@ -7226,7 +7230,7 @@ static llvm::Constant *get_value_helper(
 }
 
 static llvm::Constant *get_value(
-	ast::constant_value_storage const &value,
+	ast::constant_value const &value,
 	ast::typespec_view type,
 	ast::constant_expression const *const_expr,
 	bitcode_context &context

--- a/src/comptime/codegen.cpp
+++ b/src/comptime/codegen.cpp
@@ -5701,20 +5701,20 @@ static expr_value generate_integral_switch_code(
 			auto const &value = expr.get_constant_value();
 			switch (value.kind())
 			{
-			static_assert(ast::constant_value::variant_count == 19);
-			case ast::constant_value::sint:
+			static_assert(ast::constant_value_storage::variant_count == 19);
+			case ast::constant_value_storage::sint:
 				cases.push_back({ .value = static_cast<uint64_t>(value.get_sint()), .bb = bb, });
 				break;
-			case ast::constant_value::uint:
+			case ast::constant_value_storage::uint:
 				cases.push_back({ .value = value.get_uint(), .bb = bb, });
 				break;
-			case ast::constant_value::u8char:
+			case ast::constant_value_storage::u8char:
 				cases.push_back({ .value = static_cast<uint64_t>(value.get_u8char()), .bb = bb, });
 				break;
-			case ast::constant_value::boolean:
+			case ast::constant_value_storage::boolean:
 				cases.push_back({ .value = static_cast<uint64_t>(value.get_boolean()), .bb = bb, });
 				break;
-			case ast::constant_value::enum_:
+			case ast::constant_value_storage::enum_:
 				cases.push_back({ .value = value.get_enum().value, .bb = bb, });
 				break;
 			default:
@@ -6122,55 +6122,55 @@ static expr_value generate_expr_code(
 
 static expr_value get_constant_value(
 	lex::src_tokens const &src_tokens,
-	ast::constant_value const &value,
+	ast::constant_value_storage const &value,
 	ast::typespec_view type,
 	ast::constant_expression const *const_expr,
 	codegen_context &context,
 	bz::optional<expr_value> result_address
 );
 
-static bool is_zero_value(ast::constant_value const &value)
+static bool is_zero_value(ast::constant_value_storage const &value)
 {
 	switch (value.kind())
 	{
-	static_assert(ast::constant_value::variant_count == 19);
-	case ast::constant_value::sint:
+	static_assert(ast::constant_value_storage::variant_count == 19);
+	case ast::constant_value_storage::sint:
 		return value.get_sint() == 0;
-	case ast::constant_value::uint:
+	case ast::constant_value_storage::uint:
 		return value.get_uint() == 0;
-	case ast::constant_value::float32:
+	case ast::constant_value_storage::float32:
 		return bit_cast<uint32_t>(value.get_float32()) == 0;
-	case ast::constant_value::float64:
+	case ast::constant_value_storage::float64:
 		return bit_cast<uint64_t>(value.get_float64()) == 0;
-	case ast::constant_value::u8char:
+	case ast::constant_value_storage::u8char:
 		return value.get_u8char() == 0;
-	case ast::constant_value::string:
+	case ast::constant_value_storage::string:
 		return value.get_string() == "";
-	case ast::constant_value::boolean:
+	case ast::constant_value_storage::boolean:
 		return value.get_boolean() == false;
-	case ast::constant_value::null:
+	case ast::constant_value_storage::null:
 		return true;
-	case ast::constant_value::void_:
+	case ast::constant_value_storage::void_:
 		return true;
-	case ast::constant_value::enum_:
+	case ast::constant_value_storage::enum_:
 		return value.get_enum().value == 0;
-	case ast::constant_value::array:
+	case ast::constant_value_storage::array:
 		return value.get_array().is_all([](auto const &value) { return is_zero_value(value); });
-	case ast::constant_value::sint_array:
+	case ast::constant_value_storage::sint_array:
 		return value.get_sint_array().is_all([](auto const value) { return value == 0; });
-	case ast::constant_value::uint_array:
+	case ast::constant_value_storage::uint_array:
 		return value.get_sint_array().is_all([](auto const value) { return value == 0; });
-	case ast::constant_value::float32_array:
+	case ast::constant_value_storage::float32_array:
 		return value.get_float32_array().is_all([](auto const value) { return bit_cast<uint32_t>(value) == 0; });
-	case ast::constant_value::float64_array:
+	case ast::constant_value_storage::float64_array:
 		return value.get_float64_array().is_all([](auto const value) { return bit_cast<uint64_t>(value) == 0; });
-	case ast::constant_value::tuple:
+	case ast::constant_value_storage::tuple:
 		return value.get_tuple().is_all([](auto const &value) { return is_zero_value(value); });
-	case ast::constant_value::function:
+	case ast::constant_value_storage::function:
 		return false;
-	case ast::constant_value::aggregate:
+	case ast::constant_value_storage::aggregate:
 		return value.get_aggregate().is_all([](auto const &value) { return is_zero_value(value); });
-	case ast::constant_value::type:
+	case ast::constant_value_storage::type:
 		bz_unreachable;
 	default:
 		bz_unreachable;
@@ -6189,7 +6189,7 @@ static ast::typespec_view flattened_array_elem_type(ast::ts_array const &array_t
 
 static void get_nonzero_constant_array_value(
 	lex::src_tokens const &src_tokens,
-	bz::array_view<ast::constant_value const> values,
+	bz::array_view<ast::constant_value_storage const> values,
 	ast::ts_array const &array_type,
 	codegen_context &context,
 	expr_value result_address
@@ -6221,7 +6221,7 @@ static void get_nonzero_constant_array_value(
 
 static void get_constant_array_value(
 	lex::src_tokens const &src_tokens,
-	bz::array_view<ast::constant_value const> values,
+	bz::array_view<ast::constant_value_storage const> values,
 	ast::ts_array const &array_type,
 	codegen_context &context,
 	expr_value result_address
@@ -6428,7 +6428,7 @@ static type const *get_tuple_type(ast::typespec_view type, ast::constant_express
 
 static expr_value get_constant_value_helper(
 	lex::src_tokens const &src_tokens,
-	ast::constant_value const &value,
+	ast::constant_value_storage const &value,
 	ast::typespec_view type,
 	ast::constant_expression const *const_expr,
 	codegen_context &context,
@@ -6437,8 +6437,8 @@ static expr_value get_constant_value_helper(
 {
 	switch (value.kind())
 	{
-	static_assert(ast::constant_value::variant_count == 19);
-	case ast::constant_value::sint:
+	static_assert(ast::constant_value_storage::variant_count == 19);
+	case ast::constant_value_storage::sint:
 	{
 		auto int_value = expr_value::get_none();
 		bz_assert(type.is<ast::ts_base_type>());
@@ -6461,7 +6461,7 @@ static expr_value get_constant_value_helper(
 		}
 		return value_or_result_address(int_value, result_address, context);
 	}
-	case ast::constant_value::uint:
+	case ast::constant_value_storage::uint:
 	{
 		auto int_value = expr_value::get_none();
 		bz_assert(type.is<ast::ts_base_type>());
@@ -6484,13 +6484,13 @@ static expr_value get_constant_value_helper(
 		}
 		return value_or_result_address(int_value, result_address, context);
 	}
-	case ast::constant_value::float32:
+	case ast::constant_value_storage::float32:
 		return value_or_result_address(context.create_const_f32(value.get_float32()), result_address, context);
-	case ast::constant_value::float64:
+	case ast::constant_value_storage::float64:
 		return value_or_result_address(context.create_const_f64(value.get_float64()), result_address, context);
-	case ast::constant_value::u8char:
+	case ast::constant_value_storage::u8char:
 		return value_or_result_address(context.create_const_u32(value.get_u8char()), result_address, context);
-	case ast::constant_value::string:
+	case ast::constant_value_storage::string:
 	{
 		if (!result_address.has_value())
 		{
@@ -6514,9 +6514,9 @@ static expr_value get_constant_value_helper(
 		}
 		return result_value;
 	}
-	case ast::constant_value::boolean:
+	case ast::constant_value_storage::boolean:
 		return value_or_result_address(context.create_const_i1(value.get_boolean()), result_address, context);
-	case ast::constant_value::null:
+	case ast::constant_value_storage::null:
 		if (
 			auto const bare_type = type.remove_any_mut();
 			bare_type.is_optional_pointer_like() && !result_address.has_value()
@@ -6536,9 +6536,9 @@ static expr_value get_constant_value_helper(
 			context.create_start_lifetime(result_value);
 			return result_value;
 		}
-	case ast::constant_value::void_:
+	case ast::constant_value_storage::void_:
 		bz_unreachable;
-	case ast::constant_value::enum_:
+	case ast::constant_value_storage::enum_:
 	{
 		auto const [decl, enum_value] = value.get_enum();
 		auto const signed_enum_value = bit_cast<int64_t>(enum_value);
@@ -6576,7 +6576,7 @@ static expr_value get_constant_value_helper(
 
 		return value_or_result_address(enum_int_value, result_address, context);
 	}
-	case ast::constant_value::array:
+	case ast::constant_value_storage::array:
 	{
 		auto const array_type = type.remove_any_mut();
 		bz_assert(array_type.is<ast::ts_array>());
@@ -6593,7 +6593,7 @@ static expr_value get_constant_value_helper(
 		);
 		return result_address.get();
 	}
-	case ast::constant_value::sint_array:
+	case ast::constant_value_storage::sint_array:
 	{
 		auto const array_type = type.remove_any_mut();
 		bz_assert(array_type.is<ast::ts_array>());
@@ -6609,7 +6609,7 @@ static expr_value get_constant_value_helper(
 		);
 		return result_address.get();
 	}
-	case ast::constant_value::uint_array:
+	case ast::constant_value_storage::uint_array:
 	{
 		auto const array_type = type.remove_any_mut();
 		bz_assert(array_type.is<ast::ts_array>());
@@ -6625,7 +6625,7 @@ static expr_value get_constant_value_helper(
 		);
 		return result_address.get();
 	}
-	case ast::constant_value::float32_array:
+	case ast::constant_value_storage::float32_array:
 	{
 		auto const array_type = type.remove_any_mut();
 		bz_assert(array_type.is<ast::ts_array>());
@@ -6641,7 +6641,7 @@ static expr_value get_constant_value_helper(
 		);
 		return result_address.get();
 	}
-	case ast::constant_value::float64_array:
+	case ast::constant_value_storage::float64_array:
 	{
 		auto const array_type = type.remove_any_mut();
 		bz_assert(array_type.is<ast::ts_array>());
@@ -6657,7 +6657,7 @@ static expr_value get_constant_value_helper(
 		);
 		return result_address.get();
 	}
-	case ast::constant_value::tuple:
+	case ast::constant_value_storage::tuple:
 	{
 		if (!result_address.has_value())
 		{
@@ -6702,13 +6702,13 @@ static expr_value get_constant_value_helper(
 		}
 		return result_value;
 	}
-	case ast::constant_value::function:
+	case ast::constant_value_storage::function:
 	{
 		auto const func = context.get_function(value.get_function());
 		auto const func_ptr = context.create_const_function_pointer(func);
 		return value_or_result_address(func_ptr, result_address, context);
 	}
-	case ast::constant_value::aggregate:
+	case ast::constant_value_storage::aggregate:
 	{
 		auto const aggregate = value.get_aggregate();
 		bz_assert(type.remove_any_mut().is<ast::ts_base_type>());
@@ -6727,7 +6727,7 @@ static expr_value get_constant_value_helper(
 		}
 		return result_value;
 	}
-	case ast::constant_value::type:
+	case ast::constant_value_storage::type:
 	{
 		bz_assert(result_address.has_value());
 		auto const &result_value = result_address.get();
@@ -6741,7 +6741,7 @@ static expr_value get_constant_value_helper(
 
 static expr_value get_constant_value(
 	lex::src_tokens const &src_tokens,
-	ast::constant_value const &value,
+	ast::constant_value_storage const &value,
 	ast::typespec_view type,
 	ast::constant_expression const *const_expr,
 	codegen_context &context,

--- a/src/comptime/codegen.cpp
+++ b/src/comptime/codegen.cpp
@@ -5702,19 +5702,19 @@ static expr_value generate_integral_switch_code(
 			switch (value.kind())
 			{
 			static_assert(ast::constant_value_storage::variant_count == 19);
-			case ast::constant_value_storage::sint:
+			case ast::constant_value_kind::sint:
 				cases.push_back({ .value = static_cast<uint64_t>(value.get_sint()), .bb = bb, });
 				break;
-			case ast::constant_value_storage::uint:
+			case ast::constant_value_kind::uint:
 				cases.push_back({ .value = value.get_uint(), .bb = bb, });
 				break;
-			case ast::constant_value_storage::u8char:
+			case ast::constant_value_kind::u8char:
 				cases.push_back({ .value = static_cast<uint64_t>(value.get_u8char()), .bb = bb, });
 				break;
-			case ast::constant_value_storage::boolean:
+			case ast::constant_value_kind::boolean:
 				cases.push_back({ .value = static_cast<uint64_t>(value.get_boolean()), .bb = bb, });
 				break;
-			case ast::constant_value_storage::enum_:
+			case ast::constant_value_kind::enum_:
 				cases.push_back({ .value = value.get_enum().value, .bb = bb, });
 				break;
 			default:
@@ -6134,43 +6134,43 @@ static bool is_zero_value(ast::constant_value_storage const &value)
 	switch (value.kind())
 	{
 	static_assert(ast::constant_value_storage::variant_count == 19);
-	case ast::constant_value_storage::sint:
+	case ast::constant_value_kind::sint:
 		return value.get_sint() == 0;
-	case ast::constant_value_storage::uint:
+	case ast::constant_value_kind::uint:
 		return value.get_uint() == 0;
-	case ast::constant_value_storage::float32:
+	case ast::constant_value_kind::float32:
 		return bit_cast<uint32_t>(value.get_float32()) == 0;
-	case ast::constant_value_storage::float64:
+	case ast::constant_value_kind::float64:
 		return bit_cast<uint64_t>(value.get_float64()) == 0;
-	case ast::constant_value_storage::u8char:
+	case ast::constant_value_kind::u8char:
 		return value.get_u8char() == 0;
-	case ast::constant_value_storage::string:
+	case ast::constant_value_kind::string:
 		return value.get_string() == "";
-	case ast::constant_value_storage::boolean:
+	case ast::constant_value_kind::boolean:
 		return value.get_boolean() == false;
-	case ast::constant_value_storage::null:
+	case ast::constant_value_kind::null:
 		return true;
-	case ast::constant_value_storage::void_:
+	case ast::constant_value_kind::void_:
 		return true;
-	case ast::constant_value_storage::enum_:
+	case ast::constant_value_kind::enum_:
 		return value.get_enum().value == 0;
-	case ast::constant_value_storage::array:
+	case ast::constant_value_kind::array:
 		return value.get_array().is_all([](auto const &value) { return is_zero_value(value); });
-	case ast::constant_value_storage::sint_array:
+	case ast::constant_value_kind::sint_array:
 		return value.get_sint_array().is_all([](auto const value) { return value == 0; });
-	case ast::constant_value_storage::uint_array:
+	case ast::constant_value_kind::uint_array:
 		return value.get_sint_array().is_all([](auto const value) { return value == 0; });
-	case ast::constant_value_storage::float32_array:
+	case ast::constant_value_kind::float32_array:
 		return value.get_float32_array().is_all([](auto const value) { return bit_cast<uint32_t>(value) == 0; });
-	case ast::constant_value_storage::float64_array:
+	case ast::constant_value_kind::float64_array:
 		return value.get_float64_array().is_all([](auto const value) { return bit_cast<uint64_t>(value) == 0; });
-	case ast::constant_value_storage::tuple:
+	case ast::constant_value_kind::tuple:
 		return value.get_tuple().is_all([](auto const &value) { return is_zero_value(value); });
-	case ast::constant_value_storage::function:
+	case ast::constant_value_kind::function:
 		return false;
-	case ast::constant_value_storage::aggregate:
+	case ast::constant_value_kind::aggregate:
 		return value.get_aggregate().is_all([](auto const &value) { return is_zero_value(value); });
-	case ast::constant_value_storage::type:
+	case ast::constant_value_kind::type:
 		bz_unreachable;
 	default:
 		bz_unreachable;
@@ -6438,7 +6438,7 @@ static expr_value get_constant_value_helper(
 	switch (value.kind())
 	{
 	static_assert(ast::constant_value_storage::variant_count == 19);
-	case ast::constant_value_storage::sint:
+	case ast::constant_value_kind::sint:
 	{
 		auto int_value = expr_value::get_none();
 		bz_assert(type.is<ast::ts_base_type>());
@@ -6461,7 +6461,7 @@ static expr_value get_constant_value_helper(
 		}
 		return value_or_result_address(int_value, result_address, context);
 	}
-	case ast::constant_value_storage::uint:
+	case ast::constant_value_kind::uint:
 	{
 		auto int_value = expr_value::get_none();
 		bz_assert(type.is<ast::ts_base_type>());
@@ -6484,13 +6484,13 @@ static expr_value get_constant_value_helper(
 		}
 		return value_or_result_address(int_value, result_address, context);
 	}
-	case ast::constant_value_storage::float32:
+	case ast::constant_value_kind::float32:
 		return value_or_result_address(context.create_const_f32(value.get_float32()), result_address, context);
-	case ast::constant_value_storage::float64:
+	case ast::constant_value_kind::float64:
 		return value_or_result_address(context.create_const_f64(value.get_float64()), result_address, context);
-	case ast::constant_value_storage::u8char:
+	case ast::constant_value_kind::u8char:
 		return value_or_result_address(context.create_const_u32(value.get_u8char()), result_address, context);
-	case ast::constant_value_storage::string:
+	case ast::constant_value_kind::string:
 	{
 		if (!result_address.has_value())
 		{
@@ -6514,9 +6514,9 @@ static expr_value get_constant_value_helper(
 		}
 		return result_value;
 	}
-	case ast::constant_value_storage::boolean:
+	case ast::constant_value_kind::boolean:
 		return value_or_result_address(context.create_const_i1(value.get_boolean()), result_address, context);
-	case ast::constant_value_storage::null:
+	case ast::constant_value_kind::null:
 		if (
 			auto const bare_type = type.remove_any_mut();
 			bare_type.is_optional_pointer_like() && !result_address.has_value()
@@ -6536,9 +6536,9 @@ static expr_value get_constant_value_helper(
 			context.create_start_lifetime(result_value);
 			return result_value;
 		}
-	case ast::constant_value_storage::void_:
+	case ast::constant_value_kind::void_:
 		bz_unreachable;
-	case ast::constant_value_storage::enum_:
+	case ast::constant_value_kind::enum_:
 	{
 		auto const [decl, enum_value] = value.get_enum();
 		auto const signed_enum_value = bit_cast<int64_t>(enum_value);
@@ -6576,7 +6576,7 @@ static expr_value get_constant_value_helper(
 
 		return value_or_result_address(enum_int_value, result_address, context);
 	}
-	case ast::constant_value_storage::array:
+	case ast::constant_value_kind::array:
 	{
 		auto const array_type = type.remove_any_mut();
 		bz_assert(array_type.is<ast::ts_array>());
@@ -6593,7 +6593,7 @@ static expr_value get_constant_value_helper(
 		);
 		return result_address.get();
 	}
-	case ast::constant_value_storage::sint_array:
+	case ast::constant_value_kind::sint_array:
 	{
 		auto const array_type = type.remove_any_mut();
 		bz_assert(array_type.is<ast::ts_array>());
@@ -6609,7 +6609,7 @@ static expr_value get_constant_value_helper(
 		);
 		return result_address.get();
 	}
-	case ast::constant_value_storage::uint_array:
+	case ast::constant_value_kind::uint_array:
 	{
 		auto const array_type = type.remove_any_mut();
 		bz_assert(array_type.is<ast::ts_array>());
@@ -6625,7 +6625,7 @@ static expr_value get_constant_value_helper(
 		);
 		return result_address.get();
 	}
-	case ast::constant_value_storage::float32_array:
+	case ast::constant_value_kind::float32_array:
 	{
 		auto const array_type = type.remove_any_mut();
 		bz_assert(array_type.is<ast::ts_array>());
@@ -6641,7 +6641,7 @@ static expr_value get_constant_value_helper(
 		);
 		return result_address.get();
 	}
-	case ast::constant_value_storage::float64_array:
+	case ast::constant_value_kind::float64_array:
 	{
 		auto const array_type = type.remove_any_mut();
 		bz_assert(array_type.is<ast::ts_array>());
@@ -6657,7 +6657,7 @@ static expr_value get_constant_value_helper(
 		);
 		return result_address.get();
 	}
-	case ast::constant_value_storage::tuple:
+	case ast::constant_value_kind::tuple:
 	{
 		if (!result_address.has_value())
 		{
@@ -6702,13 +6702,13 @@ static expr_value get_constant_value_helper(
 		}
 		return result_value;
 	}
-	case ast::constant_value_storage::function:
+	case ast::constant_value_kind::function:
 	{
 		auto const func = context.get_function(value.get_function());
 		auto const func_ptr = context.create_const_function_pointer(func);
 		return value_or_result_address(func_ptr, result_address, context);
 	}
-	case ast::constant_value_storage::aggregate:
+	case ast::constant_value_kind::aggregate:
 	{
 		auto const aggregate = value.get_aggregate();
 		bz_assert(type.remove_any_mut().is<ast::ts_base_type>());
@@ -6727,7 +6727,7 @@ static expr_value get_constant_value_helper(
 		}
 		return result_value;
 	}
-	case ast::constant_value_storage::type:
+	case ast::constant_value_kind::type:
 	{
 		bz_assert(result_address.has_value());
 		auto const &result_value = result_address.get();

--- a/src/comptime/codegen.cpp
+++ b/src/comptime/codegen.cpp
@@ -5701,7 +5701,7 @@ static expr_value generate_integral_switch_code(
 			auto const &value = expr.get_constant_value();
 			switch (value.kind())
 			{
-			static_assert(ast::constant_value_storage::variant_count == 19);
+			static_assert(ast::constant_value::variant_count == 19);
 			case ast::constant_value_kind::sint:
 				cases.push_back({ .value = static_cast<uint64_t>(value.get_sint()), .bb = bb, });
 				break;
@@ -6122,18 +6122,18 @@ static expr_value generate_expr_code(
 
 static expr_value get_constant_value(
 	lex::src_tokens const &src_tokens,
-	ast::constant_value_storage const &value,
+	ast::constant_value const &value,
 	ast::typespec_view type,
 	ast::constant_expression const *const_expr,
 	codegen_context &context,
 	bz::optional<expr_value> result_address
 );
 
-static bool is_zero_value(ast::constant_value_storage const &value)
+static bool is_zero_value(ast::constant_value const &value)
 {
 	switch (value.kind())
 	{
-	static_assert(ast::constant_value_storage::variant_count == 19);
+	static_assert(ast::constant_value::variant_count == 19);
 	case ast::constant_value_kind::sint:
 		return value.get_sint() == 0;
 	case ast::constant_value_kind::uint:
@@ -6189,7 +6189,7 @@ static ast::typespec_view flattened_array_elem_type(ast::ts_array const &array_t
 
 static void get_nonzero_constant_array_value(
 	lex::src_tokens const &src_tokens,
-	bz::array_view<ast::constant_value_storage const> values,
+	bz::array_view<ast::constant_value const> values,
 	ast::ts_array const &array_type,
 	codegen_context &context,
 	expr_value result_address
@@ -6221,7 +6221,7 @@ static void get_nonzero_constant_array_value(
 
 static void get_constant_array_value(
 	lex::src_tokens const &src_tokens,
-	bz::array_view<ast::constant_value_storage const> values,
+	bz::array_view<ast::constant_value const> values,
 	ast::ts_array const &array_type,
 	codegen_context &context,
 	expr_value result_address
@@ -6428,7 +6428,7 @@ static type const *get_tuple_type(ast::typespec_view type, ast::constant_express
 
 static expr_value get_constant_value_helper(
 	lex::src_tokens const &src_tokens,
-	ast::constant_value_storage const &value,
+	ast::constant_value const &value,
 	ast::typespec_view type,
 	ast::constant_expression const *const_expr,
 	codegen_context &context,
@@ -6437,7 +6437,7 @@ static expr_value get_constant_value_helper(
 {
 	switch (value.kind())
 	{
-	static_assert(ast::constant_value_storage::variant_count == 19);
+	static_assert(ast::constant_value::variant_count == 19);
 	case ast::constant_value_kind::sint:
 	{
 		auto int_value = expr_value::get_none();
@@ -6741,7 +6741,7 @@ static expr_value get_constant_value_helper(
 
 static expr_value get_constant_value(
 	lex::src_tokens const &src_tokens,
-	ast::constant_value_storage const &value,
+	ast::constant_value const &value,
 	ast::typespec_view type,
 	ast::constant_expression const *const_expr,
 	codegen_context &context,

--- a/src/comptime/executor_context.cpp
+++ b/src/comptime/executor_context.cpp
@@ -1280,7 +1280,7 @@ bool executor_context::check_memory_leaks(void)
 	return result;
 }
 
-ast::constant_value_storage executor_context::execute_expression(ast::expression const &expr, function const &func)
+ast::constant_value executor_context::execute_expression(ast::expression const &expr, function const &func)
 {
 	this->current_function = &func;
 
@@ -1326,12 +1326,12 @@ ast::constant_value_storage executor_context::execute_expression(ast::expression
 	if (this->has_error)
 	{
 		bz_assert(this->diagnostics.not_empty());
-		return ast::constant_value_storage();
+		return ast::constant_value();
 	}
 	else if (this->check_memory_leaks())
 	{
 		bz_assert(this->diagnostics.not_empty());
-		return ast::constant_value_storage();
+		return ast::constant_value();
 	}
 
 	if (func.return_type->is_void())
@@ -1339,11 +1339,11 @@ ast::constant_value_storage executor_context::execute_expression(ast::expression
 		if (expr.get_expr_type().is_typename())
 		{
 			bz_assert(expr.is_typename());
-			return ast::constant_value_storage(expr.get_typename());
+			return this->codegen_ctx->parse_ctx->add_constant_type(expr.get_typename());
 		}
 		else
 		{
-			return ast::constant_value_storage::get_void();
+			return ast::constant_value::get_void();
 		}
 	}
 	else if (func.return_type->is_integer_type())
@@ -1351,7 +1351,7 @@ ast::constant_value_storage executor_context::execute_expression(ast::expression
 		bz_assert(func.return_type->get_builtin_kind() == builtin_type_kind::i32);
 		bz_assert(expr.get_expr_type().is_typename());
 		auto const result_index = this->ret_value.i32;
-		return ast::constant_value_storage(this->codegen_ctx->typename_result_infos[result_index].type);
+		return this->codegen_ctx->parse_ctx->add_constant_type(this->codegen_ctx->typename_result_infos[result_index].type);
 	}
 	else
 	{

--- a/src/comptime/executor_context.cpp
+++ b/src/comptime/executor_context.cpp
@@ -1280,7 +1280,7 @@ bool executor_context::check_memory_leaks(void)
 	return result;
 }
 
-ast::constant_value executor_context::execute_expression(ast::expression const &expr, function const &func)
+ast::constant_value_storage executor_context::execute_expression(ast::expression const &expr, function const &func)
 {
 	this->current_function = &func;
 
@@ -1326,12 +1326,12 @@ ast::constant_value executor_context::execute_expression(ast::expression const &
 	if (this->has_error)
 	{
 		bz_assert(this->diagnostics.not_empty());
-		return ast::constant_value();
+		return ast::constant_value_storage();
 	}
 	else if (this->check_memory_leaks())
 	{
 		bz_assert(this->diagnostics.not_empty());
-		return ast::constant_value();
+		return ast::constant_value_storage();
 	}
 
 	if (func.return_type->is_void())
@@ -1339,11 +1339,11 @@ ast::constant_value executor_context::execute_expression(ast::expression const &
 		if (expr.get_expr_type().is_typename())
 		{
 			bz_assert(expr.is_typename());
-			return ast::constant_value(expr.get_typename());
+			return ast::constant_value_storage(expr.get_typename());
 		}
 		else
 		{
-			return ast::constant_value::get_void();
+			return ast::constant_value_storage::get_void();
 		}
 	}
 	else if (func.return_type->is_integer_type())
@@ -1351,7 +1351,7 @@ ast::constant_value executor_context::execute_expression(ast::expression const &
 		bz_assert(func.return_type->get_builtin_kind() == builtin_type_kind::i32);
 		bz_assert(expr.get_expr_type().is_typename());
 		auto const result_index = this->ret_value.i32;
-		return ast::constant_value(this->codegen_ctx->typename_result_infos[result_index].type);
+		return ast::constant_value_storage(this->codegen_ctx->typename_result_infos[result_index].type);
 	}
 	else
 	{

--- a/src/comptime/executor_context.h
+++ b/src/comptime/executor_context.h
@@ -190,7 +190,7 @@ struct executor_context
 	void advance(void);
 
 	bool check_memory_leaks(void);
-	ast::constant_value execute_expression(ast::expression const &expr, function const &func);
+	ast::constant_value_storage execute_expression(ast::expression const &expr, function const &func);
 };
 
 } // namespace comptime

--- a/src/comptime/executor_context.h
+++ b/src/comptime/executor_context.h
@@ -190,7 +190,7 @@ struct executor_context
 	void advance(void);
 
 	bool check_memory_leaks(void);
-	ast::constant_value_storage execute_expression(ast::expression const &expr, function const &func);
+	ast::constant_value execute_expression(ast::expression const &expr, function const &func);
 };
 
 } // namespace comptime

--- a/src/comptime/memory_value_conversion.cpp
+++ b/src/comptime/memory_value_conversion.cpp
@@ -58,7 +58,7 @@ static void store_array(bz::array_view<U const> values, uint8_t *mem, endianness
 
 static void object_from_constant_value(
 	lex::src_tokens const &src_tokens,
-	ast::constant_value_storage const &value,
+	ast::constant_value const &value,
 	type const *object_type,
 	uint8_t *mem,
 	size_t current_offset,
@@ -345,7 +345,7 @@ static void object_from_constant_value(
 
 bz::fixed_vector<uint8_t> object_from_constant_value(
 	lex::src_tokens const &src_tokens,
-	ast::constant_value_storage const &value,
+	ast::constant_value const &value,
 	type const *object_type,
 	codegen_context &context
 )
@@ -434,29 +434,29 @@ constant_value_from_object_result_t constant_value_from_object(
 			switch (kind)
 			{
 			case ast::type_info::int8_:
-				return { ast::constant_value_storage(static_cast<int64_t>(load<int8_t>(mem, endianness))), {} };
+				return { ast::constant_value(static_cast<int64_t>(load<int8_t>(mem, endianness))), {} };
 			case ast::type_info::int16_:
-				return { ast::constant_value_storage(static_cast<int64_t>(load<int16_t>(mem, endianness))), {} };
+				return { ast::constant_value(static_cast<int64_t>(load<int16_t>(mem, endianness))), {} };
 			case ast::type_info::int32_:
-				return { ast::constant_value_storage(static_cast<int64_t>(load<int32_t>(mem, endianness))), {} };
+				return { ast::constant_value(static_cast<int64_t>(load<int32_t>(mem, endianness))), {} };
 			case ast::type_info::int64_:
-				return { ast::constant_value_storage(static_cast<int64_t>(load<int64_t>(mem, endianness))), {} };
+				return { ast::constant_value(static_cast<int64_t>(load<int64_t>(mem, endianness))), {} };
 			case ast::type_info::uint8_:
-				return { ast::constant_value_storage(static_cast<uint64_t>(load<uint8_t>(mem, endianness))), {} };
+				return { ast::constant_value(static_cast<uint64_t>(load<uint8_t>(mem, endianness))), {} };
 			case ast::type_info::uint16_:
-				return { ast::constant_value_storage(static_cast<uint64_t>(load<uint16_t>(mem, endianness))), {} };
+				return { ast::constant_value(static_cast<uint64_t>(load<uint16_t>(mem, endianness))), {} };
 			case ast::type_info::uint32_:
-				return { ast::constant_value_storage(static_cast<uint64_t>(load<uint32_t>(mem, endianness))), {} };
+				return { ast::constant_value(static_cast<uint64_t>(load<uint32_t>(mem, endianness))), {} };
 			case ast::type_info::uint64_:
-				return { ast::constant_value_storage(static_cast<uint64_t>(load<uint64_t>(mem, endianness))), {} };
+				return { ast::constant_value(static_cast<uint64_t>(load<uint64_t>(mem, endianness))), {} };
 			case ast::type_info::float32_:
-				return { ast::constant_value_storage(load<float32_t>(mem, endianness)), {} };
+				return { ast::constant_value(load<float32_t>(mem, endianness)), {} };
 			case ast::type_info::float64_:
-				return { ast::constant_value_storage(load<float64_t>(mem, endianness)), {} };
+				return { ast::constant_value(load<float64_t>(mem, endianness)), {} };
 			case ast::type_info::char_:
-				return { ast::constant_value_storage(load<bz::u8char>(mem, endianness)), {} };
+				return { ast::constant_value(load<bz::u8char>(mem, endianness)), {} };
 			case ast::type_info::bool_:
-				return { ast::constant_value_storage(load<bool>(mem, endianness)), {} };
+				return { ast::constant_value(load<bool>(mem, endianness)), {} };
 			default:
 				bz_unreachable;
 			}
@@ -470,13 +470,13 @@ constant_value_from_object_result_t constant_value_from_object(
 			switch (object_type->get_builtin_kind())
 			{
 			case builtin_type_kind::i8:
-				return { ast::constant_value_storage::get_enum(decl, static_cast<uint64_t>(load<uint8_t>(mem, endianness))), {} };
+				return { ast::constant_value::get_enum(decl, static_cast<uint64_t>(load<uint8_t>(mem, endianness))), {} };
 			case builtin_type_kind::i16:
-				return { ast::constant_value_storage::get_enum(decl, static_cast<uint64_t>(load<uint16_t>(mem, endianness))), {} };
+				return { ast::constant_value::get_enum(decl, static_cast<uint64_t>(load<uint16_t>(mem, endianness))), {} };
 			case builtin_type_kind::i32:
-				return { ast::constant_value_storage::get_enum(decl, static_cast<uint64_t>(load<uint32_t>(mem, endianness))), {} };
+				return { ast::constant_value::get_enum(decl, static_cast<uint64_t>(load<uint32_t>(mem, endianness))), {} };
 			case builtin_type_kind::i64:
-				return { ast::constant_value_storage::get_enum(decl, static_cast<uint64_t>(load<uint64_t>(mem, endianness))), {} };
+				return { ast::constant_value::get_enum(decl, static_cast<uint64_t>(load<uint64_t>(mem, endianness))), {} };
 			default:
 				bz_unreachable;
 			}
@@ -490,12 +490,12 @@ constant_value_from_object_result_t constant_value_from_object(
 		if (address == 0)
 		{
 			bz_assert(ts.is<ast::ts_optional>());
-			return { ast::constant_value_storage::get_null(), {} };
+			return { ast::constant_value::get_null(), {} };
 		}
 		else if (ts.is<ast::ts_function>() || ts.is_optional_function())
 		{
 			auto const func = context.memory.global_memory->get_function_pointer(address).func;
-			return { ast::constant_value_storage(func->func_body), {} };
+			return { ast::constant_value(func->func_body), {} };
 		}
 		else
 		{
@@ -515,8 +515,7 @@ constant_value_from_object_result_t constant_value_from_object(
 			auto const tuple_types = ts.get<ast::ts_tuple>().types.as_array_view();
 			bz_assert(aggregate_types.size() == tuple_types.size());
 
-			auto result = constant_value_from_object_result_t();
-			auto &result_vec = result.value.emplace<ast::constant_value_kind::tuple>();
+			auto result_vec = ast::arena_vector<ast::constant_value>();
 			result_vec.reserve(tuple_types.size());
 			for (auto const i : bz::iota(0, tuple_types.size()))
 			{
@@ -529,18 +528,20 @@ constant_value_from_object_result_t constant_value_from_object(
 				);
 				if (elem_value.is_null())
 				{
-					result.value.clear();
+					auto result = constant_value_from_object_result_t();
 					result.reasons.reserve(1 + elem_error_reasons.size());
 					result.reasons.push_back({
 						{}, bz::format("invalid value of type '{}' for element {} in tuple of type '{}'", tuple_types[i], i, ts)
 					});
 					result.reasons.append_move(std::move(elem_error_reasons));
-					break;
+					return result;
 				}
 
 				result_vec.push_back(std::move(elem_value));
 			}
 
+			auto result = constant_value_from_object_result_t();
+			result.value = context.codegen_ctx->parse_ctx->add_constant_tuple(std::move(result_vec));
 			return result;
 		}
 		else if (ts.is<ast::ts_optional>())
@@ -556,7 +557,7 @@ constant_value_from_object_result_t constant_value_from_object(
 			}
 			else
 			{
-				return { ast::constant_value_storage::get_null(), {} };
+				return { ast::constant_value::get_null(), {} };
 			}
 		}
 		else if (ts.is<ast::ts_base_type>())
@@ -567,7 +568,7 @@ constant_value_from_object_result_t constant_value_from_object(
 				// str or __null_t
 				if (info->kind == ast::type_info::null_t_)
 				{
-					return { ast::constant_value_storage::get_null(), {} };
+					return { ast::constant_value::get_null(), {} };
 				}
 				else
 				{
@@ -584,12 +585,12 @@ constant_value_from_object_result_t constant_value_from_object(
 
 					if (begin_ptr == 0 && end_ptr == 0)
 					{
-						return { ast::constant_value_storage(bz::u8string()), {} };
+						return { ast::constant_value(bz::u8string_view()), {} };
 					}
 					else if (context.memory.is_global(begin_ptr))
 					{
 						return {
-							ast::constant_value_storage(bz::u8string_view(
+							context.codegen_ctx->parse_ctx->add_constant_string(bz::u8string_view(
 								context.memory.get_memory(begin_ptr),
 								context.memory.get_memory(end_ptr)
 							)),
@@ -600,7 +601,7 @@ constant_value_from_object_result_t constant_value_from_object(
 					{
 						auto const elem_type = context.codegen_ctx->get_builtin_type(builtin_type_kind::i8);
 						return {
-							ast::constant_value_storage(),
+							ast::constant_value(),
 							context.memory.get_slice_construction_error_reason(begin_ptr, end_ptr, elem_type)
 						};
 					}
@@ -612,8 +613,7 @@ constant_value_from_object_result_t constant_value_from_object(
 			auto const members = info->member_variables.as_array_view();
 			bz_assert(aggregate_types.size() == members.size());
 
-			auto result = constant_value_from_object_result_t();
-			auto &result_vec = result.value.emplace<ast::constant_value_kind::aggregate>();
+			auto result_vec = ast::arena_vector<ast::constant_value>();
 			result_vec.reserve(members.size());
 			for (auto const i : bz::iota(0, members.size()))
 			{
@@ -626,7 +626,7 @@ constant_value_from_object_result_t constant_value_from_object(
 				);
 				if (elem_value.is_null())
 				{
-					result.value.clear();
+					auto result = constant_value_from_object_result_t();
 					result.reasons.reserve(1 + elem_error_reasons.size());
 					result.reasons.push_back({
 						{}, bz::format(
@@ -635,12 +635,14 @@ constant_value_from_object_result_t constant_value_from_object(
 						)
 					});
 					result.reasons.append_move(std::move(elem_error_reasons));
-					break;
+					return result;
 				}
 
 				result_vec.push_back(std::move(elem_value));
 			}
 
+			auto result = constant_value_from_object_result_t();
+			result.value = context.codegen_ctx->parse_ctx->add_constant_aggregate(std::move(result_vec));
 			return result;
 		}
 		else
@@ -668,62 +670,72 @@ constant_value_from_object_result_t constant_value_from_object(
 			{
 			case ast::type_info::int8_:
 			{
-				auto &result_array = result.value.emplace<ast::constant_value_kind::sint_array>(info.size);
+				auto result_array = ast::arena_vector<int64_t>(info.size);
 				load_array<int8_t>(mem, result_array.data(), info.size, endianness);
+				result.value = context.codegen_ctx->parse_ctx->add_constant_sint_array(std::move(result_array));
 				break;
 			}
 			case ast::type_info::int16_:
 			{
-				auto &result_array = result.value.emplace<ast::constant_value_kind::sint_array>(info.size);
+				auto result_array = ast::arena_vector<int64_t>(info.size);
 				load_array<int16_t>(mem, result_array.data(), info.size, endianness);
+				result.value = context.codegen_ctx->parse_ctx->add_constant_sint_array(std::move(result_array));
 				break;
 			}
 			case ast::type_info::int32_:
 			{
-				auto &result_array = result.value.emplace<ast::constant_value_kind::sint_array>(info.size);
+				auto result_array = ast::arena_vector<int64_t>(info.size);
 				load_array<int32_t>(mem, result_array.data(), info.size, endianness);
+				result.value = context.codegen_ctx->parse_ctx->add_constant_sint_array(std::move(result_array));
 				break;
 			}
 			case ast::type_info::int64_:
 			{
-				auto &result_array = result.value.emplace<ast::constant_value_kind::sint_array>(info.size);
+				auto result_array = ast::arena_vector<int64_t>(info.size);
 				load_array<int64_t>(mem, result_array.data(), info.size, endianness);
+				result.value = context.codegen_ctx->parse_ctx->add_constant_sint_array(std::move(result_array));
 				break;
 			}
 			case ast::type_info::uint8_:
 			{
-				auto &result_array = result.value.emplace<ast::constant_value_kind::uint_array>(info.size);
+				auto result_array = ast::arena_vector<uint64_t>(info.size);
 				load_array<uint8_t>(mem, result_array.data(), info.size, endianness);
+				result.value = context.codegen_ctx->parse_ctx->add_constant_uint_array(std::move(result_array));
 				break;
 			}
 			case ast::type_info::uint16_:
 			{
-				auto &result_array = result.value.emplace<ast::constant_value_kind::uint_array>(info.size);
+				auto result_array = ast::arena_vector<uint64_t>(info.size);
 				load_array<uint16_t>(mem, result_array.data(), info.size, endianness);
+				result.value = context.codegen_ctx->parse_ctx->add_constant_uint_array(std::move(result_array));
 				break;
 			}
 			case ast::type_info::uint32_:
 			{
-				auto &result_array = result.value.emplace<ast::constant_value_kind::uint_array>(info.size);
+				auto result_array = ast::arena_vector<uint64_t>(info.size);
 				load_array<uint32_t>(mem, result_array.data(), info.size, endianness);
+				result.value = context.codegen_ctx->parse_ctx->add_constant_uint_array(std::move(result_array));
 				break;
 			}
 			case ast::type_info::uint64_:
 			{
-				auto &result_array = result.value.emplace<ast::constant_value_kind::uint_array>(info.size);
+				auto result_array = ast::arena_vector<uint64_t>(info.size);
 				load_array<uint64_t>(mem, result_array.data(), info.size, endianness);
+				result.value = context.codegen_ctx->parse_ctx->add_constant_uint_array(std::move(result_array));
 				break;
 			}
 			case ast::type_info::float32_:
 			{
-				auto &result_array = result.value.emplace<ast::constant_value_kind::float32_array>(info.size);
+				auto result_array = ast::arena_vector<float32_t>(info.size);
 				load_array<float32_t>(mem, result_array.data(), info.size, endianness);
+				result.value = context.codegen_ctx->parse_ctx->add_constant_float32_array(std::move(result_array));
 				break;
 			}
 			case ast::type_info::float64_:
 			{
-				auto &result_array = result.value.emplace<ast::constant_value_kind::float64_array>(info.size);
+				auto result_array = ast::arena_vector<float64_t>(info.size);
 				load_array<float64_t>(mem, result_array.data(), info.size, endianness);
+				result.value = context.codegen_ctx->parse_ctx->add_constant_float64_array(std::move(result_array));
 				break;
 			}
 			default:
@@ -737,8 +749,7 @@ constant_value_from_object_result_t constant_value_from_object(
 			auto const elem_type = get_multi_dimensional_array_elem_type(object_type);
 			bz_assert(elem_type->size * info.size == object_type->size);
 
-			auto result = constant_value_from_object_result_t();
-			auto &result_array = result.value.emplace<ast::constant_value_kind::array>();
+			auto result_array = ast::arena_vector<ast::constant_value>();
 			result_array.reserve(info.size);
 
 			auto mem_it = mem;
@@ -754,7 +765,7 @@ constant_value_from_object_result_t constant_value_from_object(
 				);
 				if (elem_value.is_null())
 				{
-					result.value.clear();
+					auto result = constant_value_from_object_result_t();
 					auto index = static_cast<size_t>(mem_it - mem) / elem_type->size;
 					auto total_size = info.size;
 					auto array_ts = ts;
@@ -773,12 +784,14 @@ constant_value_from_object_result_t constant_value_from_object(
 						array_ts = elem_type;
 					} while (array_ts.is<ast::ts_array>());
 					result.reasons.append_move(std::move(elem_error_reasons));
-					break;
+					return result;
 				}
 
 				result_array.push_back(std::move(elem_value));
 			}
 
+			auto result = constant_value_from_object_result_t();
+			result.value = context.codegen_ctx->parse_ctx->add_constant_array(std::move(result_array));
 			return result;
 		}
 	}

--- a/src/comptime/memory_value_conversion.cpp
+++ b/src/comptime/memory_value_conversion.cpp
@@ -58,7 +58,7 @@ static void store_array(bz::array_view<U const> values, uint8_t *mem, endianness
 
 static void object_from_constant_value(
 	lex::src_tokens const &src_tokens,
-	ast::constant_value const &value,
+	ast::constant_value_storage const &value,
 	type const *object_type,
 	uint8_t *mem,
 	size_t current_offset,
@@ -68,7 +68,7 @@ static void object_from_constant_value(
 	auto const endianness = context.get_endianness();
 	switch (value.kind())
 	{
-	case ast::constant_value::sint:
+	case ast::constant_value_storage::sint:
 		bz_assert(object_type->is_integer_type());
 		switch (object_type->get_builtin_kind())
 		{
@@ -88,7 +88,7 @@ static void object_from_constant_value(
 			bz_unreachable;
 		}
 		break;
-	case ast::constant_value::uint:
+	case ast::constant_value_storage::uint:
 		bz_assert(object_type->is_integer_type());
 		switch (object_type->get_builtin_kind())
 		{
@@ -108,20 +108,20 @@ static void object_from_constant_value(
 			bz_unreachable;
 		}
 		break;
-	case ast::constant_value::float32:
+	case ast::constant_value_storage::float32:
 		bz_assert(object_type->is_floating_point_type() && object_type->get_builtin_kind() == builtin_type_kind::f32);
 		store<float32_t>(value.get_float32(), mem, endianness);
 		break;
-	case ast::constant_value::float64:
+	case ast::constant_value_storage::float64:
 		bz_assert(object_type->is_floating_point_type() && object_type->get_builtin_kind() == builtin_type_kind::f64);
 		store<float64_t>(value.get_float64(), mem, endianness);
 		break;
-	case ast::constant_value::u8char:
+	case ast::constant_value_storage::u8char:
 		bz_assert(object_type->is_integer_type() && object_type->get_builtin_kind() == builtin_type_kind::i32);
 		static_assert(sizeof (bz::u8char) == 4);
 		store<bz::u8char>(value.get_u8char(), mem, endianness);
 		break;
-	case ast::constant_value::string:
+	case ast::constant_value_storage::string:
 	{
 		auto const str = value.get_string();
 		if (str.size() == 0)
@@ -156,17 +156,17 @@ static void object_from_constant_value(
 		}
 		break;
 	}
-	case ast::constant_value::boolean:
+	case ast::constant_value_storage::boolean:
 		bz_assert(object_type->is_integer_type() && object_type->get_builtin_kind() == builtin_type_kind::i1);
 		store<bool>(value.get_boolean(), mem, endianness);
 		break;
-	case ast::constant_value::null:
+	case ast::constant_value_storage::null:
 		// pointers are set to null, optionals are set to not having a value
 		std::memset(mem, 0, object_type->size);
 		break;
-	case ast::constant_value::void_:
+	case ast::constant_value_storage::void_:
 		bz_unreachable;
-	case ast::constant_value::enum_:
+	case ast::constant_value_storage::enum_:
 		bz_assert(object_type->is_integer_type());
 		switch (object_type->get_builtin_kind())
 		{
@@ -186,7 +186,7 @@ static void object_from_constant_value(
 			bz_unreachable;
 		}
 		break;
-	case ast::constant_value::array:
+	case ast::constant_value_storage::array:
 	{
 		bz_assert(object_type->is_array());
 		auto const elem_type = get_multi_dimensional_array_elem_type(object_type);
@@ -201,7 +201,7 @@ static void object_from_constant_value(
 		}
 		break;
 	}
-	case ast::constant_value::sint_array:
+	case ast::constant_value_storage::sint_array:
 	{
 		bz_assert(object_type->is_array());
 		auto const elem_type = get_multi_dimensional_array_elem_type(object_type);
@@ -227,7 +227,7 @@ static void object_from_constant_value(
 		}
 		break;
 	}
-	case ast::constant_value::uint_array:
+	case ast::constant_value_storage::uint_array:
 	{
 		bz_assert(object_type->is_array());
 		auto const elem_type = get_multi_dimensional_array_elem_type(object_type);
@@ -253,7 +253,7 @@ static void object_from_constant_value(
 		}
 		break;
 	}
-	case ast::constant_value::float32_array:
+	case ast::constant_value_storage::float32_array:
 	{
 		bz_assert(object_type->is_array());
 		auto const array = value.get_float32_array();
@@ -265,7 +265,7 @@ static void object_from_constant_value(
 		store_array<float32_t>(array, mem, endianness);
 		break;
 	}
-	case ast::constant_value::float64_array:
+	case ast::constant_value_storage::float64_array:
 	{
 		bz_assert(object_type->is_array());
 		auto const array = value.get_float64_array();
@@ -277,7 +277,7 @@ static void object_from_constant_value(
 		store_array<float64_t>(array, mem, endianness);
 		break;
 	}
-	case ast::constant_value::tuple:
+	case ast::constant_value_storage::tuple:
 	{
 		auto const values = value.get_tuple();
 		bz_assert(object_type->is_aggregate());
@@ -298,7 +298,7 @@ static void object_from_constant_value(
 		}
 		break;
 	}
-	case ast::constant_value::function:
+	case ast::constant_value_storage::function:
 	{
 		auto const func_body = value.get_function();
 		auto const func = context.get_function(func_body);
@@ -315,9 +315,9 @@ static void object_from_constant_value(
 		}
 		break;
 	}
-	case ast::constant_value::type:
+	case ast::constant_value_storage::type:
 		bz_unreachable;
-	case ast::constant_value::aggregate:
+	case ast::constant_value_storage::aggregate:
 	{
 		auto const values = value.get_aggregate();
 		bz_assert(object_type->is_aggregate());
@@ -345,7 +345,7 @@ static void object_from_constant_value(
 
 bz::fixed_vector<uint8_t> object_from_constant_value(
 	lex::src_tokens const &src_tokens,
-	ast::constant_value const &value,
+	ast::constant_value_storage const &value,
 	type const *object_type,
 	codegen_context &context
 )
@@ -434,29 +434,29 @@ constant_value_from_object_result_t constant_value_from_object(
 			switch (kind)
 			{
 			case ast::type_info::int8_:
-				return { ast::constant_value(static_cast<int64_t>(load<int8_t>(mem, endianness))), {} };
+				return { ast::constant_value_storage(static_cast<int64_t>(load<int8_t>(mem, endianness))), {} };
 			case ast::type_info::int16_:
-				return { ast::constant_value(static_cast<int64_t>(load<int16_t>(mem, endianness))), {} };
+				return { ast::constant_value_storage(static_cast<int64_t>(load<int16_t>(mem, endianness))), {} };
 			case ast::type_info::int32_:
-				return { ast::constant_value(static_cast<int64_t>(load<int32_t>(mem, endianness))), {} };
+				return { ast::constant_value_storage(static_cast<int64_t>(load<int32_t>(mem, endianness))), {} };
 			case ast::type_info::int64_:
-				return { ast::constant_value(static_cast<int64_t>(load<int64_t>(mem, endianness))), {} };
+				return { ast::constant_value_storage(static_cast<int64_t>(load<int64_t>(mem, endianness))), {} };
 			case ast::type_info::uint8_:
-				return { ast::constant_value(static_cast<uint64_t>(load<uint8_t>(mem, endianness))), {} };
+				return { ast::constant_value_storage(static_cast<uint64_t>(load<uint8_t>(mem, endianness))), {} };
 			case ast::type_info::uint16_:
-				return { ast::constant_value(static_cast<uint64_t>(load<uint16_t>(mem, endianness))), {} };
+				return { ast::constant_value_storage(static_cast<uint64_t>(load<uint16_t>(mem, endianness))), {} };
 			case ast::type_info::uint32_:
-				return { ast::constant_value(static_cast<uint64_t>(load<uint32_t>(mem, endianness))), {} };
+				return { ast::constant_value_storage(static_cast<uint64_t>(load<uint32_t>(mem, endianness))), {} };
 			case ast::type_info::uint64_:
-				return { ast::constant_value(static_cast<uint64_t>(load<uint64_t>(mem, endianness))), {} };
+				return { ast::constant_value_storage(static_cast<uint64_t>(load<uint64_t>(mem, endianness))), {} };
 			case ast::type_info::float32_:
-				return { ast::constant_value(load<float32_t>(mem, endianness)), {} };
+				return { ast::constant_value_storage(load<float32_t>(mem, endianness)), {} };
 			case ast::type_info::float64_:
-				return { ast::constant_value(load<float64_t>(mem, endianness)), {} };
+				return { ast::constant_value_storage(load<float64_t>(mem, endianness)), {} };
 			case ast::type_info::char_:
-				return { ast::constant_value(load<bz::u8char>(mem, endianness)), {} };
+				return { ast::constant_value_storage(load<bz::u8char>(mem, endianness)), {} };
 			case ast::type_info::bool_:
-				return { ast::constant_value(load<bool>(mem, endianness)), {} };
+				return { ast::constant_value_storage(load<bool>(mem, endianness)), {} };
 			default:
 				bz_unreachable;
 			}
@@ -470,13 +470,13 @@ constant_value_from_object_result_t constant_value_from_object(
 			switch (object_type->get_builtin_kind())
 			{
 			case builtin_type_kind::i8:
-				return { ast::constant_value::get_enum(decl, static_cast<uint64_t>(load<uint8_t>(mem, endianness))), {} };
+				return { ast::constant_value_storage::get_enum(decl, static_cast<uint64_t>(load<uint8_t>(mem, endianness))), {} };
 			case builtin_type_kind::i16:
-				return { ast::constant_value::get_enum(decl, static_cast<uint64_t>(load<uint16_t>(mem, endianness))), {} };
+				return { ast::constant_value_storage::get_enum(decl, static_cast<uint64_t>(load<uint16_t>(mem, endianness))), {} };
 			case builtin_type_kind::i32:
-				return { ast::constant_value::get_enum(decl, static_cast<uint64_t>(load<uint32_t>(mem, endianness))), {} };
+				return { ast::constant_value_storage::get_enum(decl, static_cast<uint64_t>(load<uint32_t>(mem, endianness))), {} };
 			case builtin_type_kind::i64:
-				return { ast::constant_value::get_enum(decl, static_cast<uint64_t>(load<uint64_t>(mem, endianness))), {} };
+				return { ast::constant_value_storage::get_enum(decl, static_cast<uint64_t>(load<uint64_t>(mem, endianness))), {} };
 			default:
 				bz_unreachable;
 			}
@@ -490,12 +490,12 @@ constant_value_from_object_result_t constant_value_from_object(
 		if (address == 0)
 		{
 			bz_assert(ts.is<ast::ts_optional>());
-			return { ast::constant_value::get_null(), {} };
+			return { ast::constant_value_storage::get_null(), {} };
 		}
 		else if (ts.is<ast::ts_function>() || ts.is_optional_function())
 		{
 			auto const func = context.memory.global_memory->get_function_pointer(address).func;
-			return { ast::constant_value(func->func_body), {} };
+			return { ast::constant_value_storage(func->func_body), {} };
 		}
 		else
 		{
@@ -516,7 +516,7 @@ constant_value_from_object_result_t constant_value_from_object(
 			bz_assert(aggregate_types.size() == tuple_types.size());
 
 			auto result = constant_value_from_object_result_t();
-			auto &result_vec = result.value.emplace<ast::constant_value::tuple>();
+			auto &result_vec = result.value.emplace<ast::constant_value_storage::tuple>();
 			result_vec.reserve(tuple_types.size());
 			for (auto const i : bz::iota(0, tuple_types.size()))
 			{
@@ -556,7 +556,7 @@ constant_value_from_object_result_t constant_value_from_object(
 			}
 			else
 			{
-				return { ast::constant_value::get_null(), {} };
+				return { ast::constant_value_storage::get_null(), {} };
 			}
 		}
 		else if (ts.is<ast::ts_base_type>())
@@ -567,7 +567,7 @@ constant_value_from_object_result_t constant_value_from_object(
 				// str or __null_t
 				if (info->kind == ast::type_info::null_t_)
 				{
-					return { ast::constant_value::get_null(), {} };
+					return { ast::constant_value_storage::get_null(), {} };
 				}
 				else
 				{
@@ -584,12 +584,12 @@ constant_value_from_object_result_t constant_value_from_object(
 
 					if (begin_ptr == 0 && end_ptr == 0)
 					{
-						return { ast::constant_value(bz::u8string()), {} };
+						return { ast::constant_value_storage(bz::u8string()), {} };
 					}
 					else if (context.memory.is_global(begin_ptr))
 					{
 						return {
-							ast::constant_value(bz::u8string_view(
+							ast::constant_value_storage(bz::u8string_view(
 								context.memory.get_memory(begin_ptr),
 								context.memory.get_memory(end_ptr)
 							)),
@@ -600,7 +600,7 @@ constant_value_from_object_result_t constant_value_from_object(
 					{
 						auto const elem_type = context.codegen_ctx->get_builtin_type(builtin_type_kind::i8);
 						return {
-							ast::constant_value(),
+							ast::constant_value_storage(),
 							context.memory.get_slice_construction_error_reason(begin_ptr, end_ptr, elem_type)
 						};
 					}
@@ -613,7 +613,7 @@ constant_value_from_object_result_t constant_value_from_object(
 			bz_assert(aggregate_types.size() == members.size());
 
 			auto result = constant_value_from_object_result_t();
-			auto &result_vec = result.value.emplace<ast::constant_value::aggregate>();
+			auto &result_vec = result.value.emplace<ast::constant_value_storage::aggregate>();
 			result_vec.reserve(members.size());
 			for (auto const i : bz::iota(0, members.size()))
 			{
@@ -668,61 +668,61 @@ constant_value_from_object_result_t constant_value_from_object(
 			{
 			case ast::type_info::int8_:
 			{
-				auto &result_array = result.value.emplace<ast::constant_value::sint_array>(info.size);
+				auto &result_array = result.value.emplace<ast::constant_value_storage::sint_array>(info.size);
 				load_array<int8_t>(mem, result_array.data(), info.size, endianness);
 				break;
 			}
 			case ast::type_info::int16_:
 			{
-				auto &result_array = result.value.emplace<ast::constant_value::sint_array>(info.size);
+				auto &result_array = result.value.emplace<ast::constant_value_storage::sint_array>(info.size);
 				load_array<int16_t>(mem, result_array.data(), info.size, endianness);
 				break;
 			}
 			case ast::type_info::int32_:
 			{
-				auto &result_array = result.value.emplace<ast::constant_value::sint_array>(info.size);
+				auto &result_array = result.value.emplace<ast::constant_value_storage::sint_array>(info.size);
 				load_array<int32_t>(mem, result_array.data(), info.size, endianness);
 				break;
 			}
 			case ast::type_info::int64_:
 			{
-				auto &result_array = result.value.emplace<ast::constant_value::sint_array>(info.size);
+				auto &result_array = result.value.emplace<ast::constant_value_storage::sint_array>(info.size);
 				load_array<int64_t>(mem, result_array.data(), info.size, endianness);
 				break;
 			}
 			case ast::type_info::uint8_:
 			{
-				auto &result_array = result.value.emplace<ast::constant_value::uint_array>(info.size);
+				auto &result_array = result.value.emplace<ast::constant_value_storage::uint_array>(info.size);
 				load_array<uint8_t>(mem, result_array.data(), info.size, endianness);
 				break;
 			}
 			case ast::type_info::uint16_:
 			{
-				auto &result_array = result.value.emplace<ast::constant_value::uint_array>(info.size);
+				auto &result_array = result.value.emplace<ast::constant_value_storage::uint_array>(info.size);
 				load_array<uint16_t>(mem, result_array.data(), info.size, endianness);
 				break;
 			}
 			case ast::type_info::uint32_:
 			{
-				auto &result_array = result.value.emplace<ast::constant_value::uint_array>(info.size);
+				auto &result_array = result.value.emplace<ast::constant_value_storage::uint_array>(info.size);
 				load_array<uint32_t>(mem, result_array.data(), info.size, endianness);
 				break;
 			}
 			case ast::type_info::uint64_:
 			{
-				auto &result_array = result.value.emplace<ast::constant_value::uint_array>(info.size);
+				auto &result_array = result.value.emplace<ast::constant_value_storage::uint_array>(info.size);
 				load_array<uint64_t>(mem, result_array.data(), info.size, endianness);
 				break;
 			}
 			case ast::type_info::float32_:
 			{
-				auto &result_array = result.value.emplace<ast::constant_value::float32_array>(info.size);
+				auto &result_array = result.value.emplace<ast::constant_value_storage::float32_array>(info.size);
 				load_array<float32_t>(mem, result_array.data(), info.size, endianness);
 				break;
 			}
 			case ast::type_info::float64_:
 			{
-				auto &result_array = result.value.emplace<ast::constant_value::float64_array>(info.size);
+				auto &result_array = result.value.emplace<ast::constant_value_storage::float64_array>(info.size);
 				load_array<float64_t>(mem, result_array.data(), info.size, endianness);
 				break;
 			}
@@ -738,7 +738,7 @@ constant_value_from_object_result_t constant_value_from_object(
 			bz_assert(elem_type->size * info.size == object_type->size);
 
 			auto result = constant_value_from_object_result_t();
-			auto &result_array = result.value.emplace<ast::constant_value::array>();
+			auto &result_array = result.value.emplace<ast::constant_value_storage::array>();
 			result_array.reserve(info.size);
 
 			auto mem_it = mem;

--- a/src/comptime/memory_value_conversion.cpp
+++ b/src/comptime/memory_value_conversion.cpp
@@ -68,7 +68,7 @@ static void object_from_constant_value(
 	auto const endianness = context.get_endianness();
 	switch (value.kind())
 	{
-	case ast::constant_value_storage::sint:
+	case ast::constant_value_kind::sint:
 		bz_assert(object_type->is_integer_type());
 		switch (object_type->get_builtin_kind())
 		{
@@ -88,7 +88,7 @@ static void object_from_constant_value(
 			bz_unreachable;
 		}
 		break;
-	case ast::constant_value_storage::uint:
+	case ast::constant_value_kind::uint:
 		bz_assert(object_type->is_integer_type());
 		switch (object_type->get_builtin_kind())
 		{
@@ -108,20 +108,20 @@ static void object_from_constant_value(
 			bz_unreachable;
 		}
 		break;
-	case ast::constant_value_storage::float32:
+	case ast::constant_value_kind::float32:
 		bz_assert(object_type->is_floating_point_type() && object_type->get_builtin_kind() == builtin_type_kind::f32);
 		store<float32_t>(value.get_float32(), mem, endianness);
 		break;
-	case ast::constant_value_storage::float64:
+	case ast::constant_value_kind::float64:
 		bz_assert(object_type->is_floating_point_type() && object_type->get_builtin_kind() == builtin_type_kind::f64);
 		store<float64_t>(value.get_float64(), mem, endianness);
 		break;
-	case ast::constant_value_storage::u8char:
+	case ast::constant_value_kind::u8char:
 		bz_assert(object_type->is_integer_type() && object_type->get_builtin_kind() == builtin_type_kind::i32);
 		static_assert(sizeof (bz::u8char) == 4);
 		store<bz::u8char>(value.get_u8char(), mem, endianness);
 		break;
-	case ast::constant_value_storage::string:
+	case ast::constant_value_kind::string:
 	{
 		auto const str = value.get_string();
 		if (str.size() == 0)
@@ -156,17 +156,17 @@ static void object_from_constant_value(
 		}
 		break;
 	}
-	case ast::constant_value_storage::boolean:
+	case ast::constant_value_kind::boolean:
 		bz_assert(object_type->is_integer_type() && object_type->get_builtin_kind() == builtin_type_kind::i1);
 		store<bool>(value.get_boolean(), mem, endianness);
 		break;
-	case ast::constant_value_storage::null:
+	case ast::constant_value_kind::null:
 		// pointers are set to null, optionals are set to not having a value
 		std::memset(mem, 0, object_type->size);
 		break;
-	case ast::constant_value_storage::void_:
+	case ast::constant_value_kind::void_:
 		bz_unreachable;
-	case ast::constant_value_storage::enum_:
+	case ast::constant_value_kind::enum_:
 		bz_assert(object_type->is_integer_type());
 		switch (object_type->get_builtin_kind())
 		{
@@ -186,7 +186,7 @@ static void object_from_constant_value(
 			bz_unreachable;
 		}
 		break;
-	case ast::constant_value_storage::array:
+	case ast::constant_value_kind::array:
 	{
 		bz_assert(object_type->is_array());
 		auto const elem_type = get_multi_dimensional_array_elem_type(object_type);
@@ -201,7 +201,7 @@ static void object_from_constant_value(
 		}
 		break;
 	}
-	case ast::constant_value_storage::sint_array:
+	case ast::constant_value_kind::sint_array:
 	{
 		bz_assert(object_type->is_array());
 		auto const elem_type = get_multi_dimensional_array_elem_type(object_type);
@@ -227,7 +227,7 @@ static void object_from_constant_value(
 		}
 		break;
 	}
-	case ast::constant_value_storage::uint_array:
+	case ast::constant_value_kind::uint_array:
 	{
 		bz_assert(object_type->is_array());
 		auto const elem_type = get_multi_dimensional_array_elem_type(object_type);
@@ -253,7 +253,7 @@ static void object_from_constant_value(
 		}
 		break;
 	}
-	case ast::constant_value_storage::float32_array:
+	case ast::constant_value_kind::float32_array:
 	{
 		bz_assert(object_type->is_array());
 		auto const array = value.get_float32_array();
@@ -265,7 +265,7 @@ static void object_from_constant_value(
 		store_array<float32_t>(array, mem, endianness);
 		break;
 	}
-	case ast::constant_value_storage::float64_array:
+	case ast::constant_value_kind::float64_array:
 	{
 		bz_assert(object_type->is_array());
 		auto const array = value.get_float64_array();
@@ -277,7 +277,7 @@ static void object_from_constant_value(
 		store_array<float64_t>(array, mem, endianness);
 		break;
 	}
-	case ast::constant_value_storage::tuple:
+	case ast::constant_value_kind::tuple:
 	{
 		auto const values = value.get_tuple();
 		bz_assert(object_type->is_aggregate());
@@ -298,7 +298,7 @@ static void object_from_constant_value(
 		}
 		break;
 	}
-	case ast::constant_value_storage::function:
+	case ast::constant_value_kind::function:
 	{
 		auto const func_body = value.get_function();
 		auto const func = context.get_function(func_body);
@@ -315,9 +315,9 @@ static void object_from_constant_value(
 		}
 		break;
 	}
-	case ast::constant_value_storage::type:
+	case ast::constant_value_kind::type:
 		bz_unreachable;
-	case ast::constant_value_storage::aggregate:
+	case ast::constant_value_kind::aggregate:
 	{
 		auto const values = value.get_aggregate();
 		bz_assert(object_type->is_aggregate());
@@ -516,7 +516,7 @@ constant_value_from_object_result_t constant_value_from_object(
 			bz_assert(aggregate_types.size() == tuple_types.size());
 
 			auto result = constant_value_from_object_result_t();
-			auto &result_vec = result.value.emplace<ast::constant_value_storage::tuple>();
+			auto &result_vec = result.value.emplace<ast::constant_value_kind::tuple>();
 			result_vec.reserve(tuple_types.size());
 			for (auto const i : bz::iota(0, tuple_types.size()))
 			{
@@ -613,7 +613,7 @@ constant_value_from_object_result_t constant_value_from_object(
 			bz_assert(aggregate_types.size() == members.size());
 
 			auto result = constant_value_from_object_result_t();
-			auto &result_vec = result.value.emplace<ast::constant_value_storage::aggregate>();
+			auto &result_vec = result.value.emplace<ast::constant_value_kind::aggregate>();
 			result_vec.reserve(members.size());
 			for (auto const i : bz::iota(0, members.size()))
 			{
@@ -668,61 +668,61 @@ constant_value_from_object_result_t constant_value_from_object(
 			{
 			case ast::type_info::int8_:
 			{
-				auto &result_array = result.value.emplace<ast::constant_value_storage::sint_array>(info.size);
+				auto &result_array = result.value.emplace<ast::constant_value_kind::sint_array>(info.size);
 				load_array<int8_t>(mem, result_array.data(), info.size, endianness);
 				break;
 			}
 			case ast::type_info::int16_:
 			{
-				auto &result_array = result.value.emplace<ast::constant_value_storage::sint_array>(info.size);
+				auto &result_array = result.value.emplace<ast::constant_value_kind::sint_array>(info.size);
 				load_array<int16_t>(mem, result_array.data(), info.size, endianness);
 				break;
 			}
 			case ast::type_info::int32_:
 			{
-				auto &result_array = result.value.emplace<ast::constant_value_storage::sint_array>(info.size);
+				auto &result_array = result.value.emplace<ast::constant_value_kind::sint_array>(info.size);
 				load_array<int32_t>(mem, result_array.data(), info.size, endianness);
 				break;
 			}
 			case ast::type_info::int64_:
 			{
-				auto &result_array = result.value.emplace<ast::constant_value_storage::sint_array>(info.size);
+				auto &result_array = result.value.emplace<ast::constant_value_kind::sint_array>(info.size);
 				load_array<int64_t>(mem, result_array.data(), info.size, endianness);
 				break;
 			}
 			case ast::type_info::uint8_:
 			{
-				auto &result_array = result.value.emplace<ast::constant_value_storage::uint_array>(info.size);
+				auto &result_array = result.value.emplace<ast::constant_value_kind::uint_array>(info.size);
 				load_array<uint8_t>(mem, result_array.data(), info.size, endianness);
 				break;
 			}
 			case ast::type_info::uint16_:
 			{
-				auto &result_array = result.value.emplace<ast::constant_value_storage::uint_array>(info.size);
+				auto &result_array = result.value.emplace<ast::constant_value_kind::uint_array>(info.size);
 				load_array<uint16_t>(mem, result_array.data(), info.size, endianness);
 				break;
 			}
 			case ast::type_info::uint32_:
 			{
-				auto &result_array = result.value.emplace<ast::constant_value_storage::uint_array>(info.size);
+				auto &result_array = result.value.emplace<ast::constant_value_kind::uint_array>(info.size);
 				load_array<uint32_t>(mem, result_array.data(), info.size, endianness);
 				break;
 			}
 			case ast::type_info::uint64_:
 			{
-				auto &result_array = result.value.emplace<ast::constant_value_storage::uint_array>(info.size);
+				auto &result_array = result.value.emplace<ast::constant_value_kind::uint_array>(info.size);
 				load_array<uint64_t>(mem, result_array.data(), info.size, endianness);
 				break;
 			}
 			case ast::type_info::float32_:
 			{
-				auto &result_array = result.value.emplace<ast::constant_value_storage::float32_array>(info.size);
+				auto &result_array = result.value.emplace<ast::constant_value_kind::float32_array>(info.size);
 				load_array<float32_t>(mem, result_array.data(), info.size, endianness);
 				break;
 			}
 			case ast::type_info::float64_:
 			{
-				auto &result_array = result.value.emplace<ast::constant_value_storage::float64_array>(info.size);
+				auto &result_array = result.value.emplace<ast::constant_value_kind::float64_array>(info.size);
 				load_array<float64_t>(mem, result_array.data(), info.size, endianness);
 				break;
 			}
@@ -738,7 +738,7 @@ constant_value_from_object_result_t constant_value_from_object(
 			bz_assert(elem_type->size * info.size == object_type->size);
 
 			auto result = constant_value_from_object_result_t();
-			auto &result_array = result.value.emplace<ast::constant_value_storage::array>();
+			auto &result_array = result.value.emplace<ast::constant_value_kind::array>();
 			result_array.reserve(info.size);
 
 			auto mem_it = mem;

--- a/src/comptime/memory_value_conversion.h
+++ b/src/comptime/memory_value_conversion.h
@@ -12,14 +12,14 @@ namespace comptime::memory
 
 bz::fixed_vector<uint8_t> object_from_constant_value(
 	lex::src_tokens const &src_tokens,
-	ast::constant_value const &value,
+	ast::constant_value_storage const &value,
 	type const *object_type,
 	codegen_context &context
 );
 
 struct constant_value_from_object_result_t
 {
-	ast::constant_value value;
+	ast::constant_value_storage value;
 	bz::vector<error_reason_t> reasons;
 };
 

--- a/src/comptime/memory_value_conversion.h
+++ b/src/comptime/memory_value_conversion.h
@@ -12,14 +12,14 @@ namespace comptime::memory
 
 bz::fixed_vector<uint8_t> object_from_constant_value(
 	lex::src_tokens const &src_tokens,
-	ast::constant_value_storage const &value,
+	ast::constant_value const &value,
 	type const *object_type,
 	codegen_context &context
 );
 
 struct constant_value_from_object_result_t
 {
-	ast::constant_value_storage value;
+	ast::constant_value value;
 	bz::vector<error_reason_t> reasons;
 };
 

--- a/src/ctx/builtin_operators.cpp
+++ b/src/ctx/builtin_operators.cpp
@@ -28,7 +28,7 @@ static auto get_constant_expression_values(
 	ast::expression const &rhs
 )
 {
-	static_assert(kind != ast::constant_value::aggregate);
+	static_assert(kind != ast::constant_value_storage::aggregate);
 	bz_assert(lhs.is_constant());
 	bz_assert(rhs.is_constant());
 	auto const &lhs_value = lhs.get_constant_value();
@@ -36,7 +36,7 @@ static auto get_constant_expression_values(
 	bz_assert(lhs_value.kind() == kind);
 	bz_assert(rhs_value.kind() == kind);
 
-	if constexpr (kind == ast::constant_value::string)
+	if constexpr (kind == ast::constant_value_storage::string)
 	{
 		return std::make_pair(
 			lhs_value.get_string(),
@@ -143,7 +143,7 @@ static ast::expression get_type_op_unary_reference(
 		src_tokens,
 		ast::expression_type_kind::type_name,
 		ast::make_typename_typespec(nullptr),
-		ast::constant_value(std::move(result_type)),
+		ast::constant_value_storage(std::move(result_type)),
 		ast::make_expr_unary_op(op_kind, std::move(expr))
 	);
 }
@@ -200,7 +200,7 @@ static ast::expression get_type_op_unary_auto_ref(
 		src_tokens,
 		ast::expression_type_kind::type_name,
 		ast::make_typename_typespec(nullptr),
-		ast::constant_value(std::move(result_type)),
+		ast::constant_value_storage(std::move(result_type)),
 		ast::make_expr_unary_op(op_kind, std::move(expr))
 	);
 }
@@ -269,7 +269,7 @@ static ast::expression get_type_op_unary_auto_ref_const(
 		src_tokens,
 		ast::expression_type_kind::type_name,
 		ast::make_typename_typespec(nullptr),
-		ast::constant_value(std::move(result_type)),
+		ast::constant_value_storage(std::move(result_type)),
 		ast::make_expr_unary_op(op_kind, std::move(expr))
 	);
 }
@@ -325,7 +325,7 @@ static ast::expression get_type_op_unary_pointer(
 		src_tokens,
 		ast::expression_type_kind::type_name,
 		ast::make_typename_typespec(nullptr),
-		ast::constant_value(std::move(result_type)),
+		ast::constant_value_storage(std::move(result_type)),
 		ast::make_expr_unary_op(op_kind, std::move(expr))
 	);
 }
@@ -376,7 +376,7 @@ static ast::expression get_type_op_unary_question_mark(
 		src_tokens,
 		ast::expression_type_kind::type_name,
 		ast::make_typename_typespec(nullptr),
-		ast::constant_value(std::move(result_type)),
+		ast::constant_value_storage(std::move(result_type)),
 		ast::make_expr_unary_op(op_kind, std::move(expr))
 	);
 }
@@ -407,7 +407,7 @@ static ast::expression get_type_op_unary_dot_dot_dot(
 		src_tokens,
 		ast::expression_type_kind::type_name,
 		ast::make_typename_typespec(nullptr),
-		ast::constant_value(std::move(result_type)),
+		ast::constant_value_storage(std::move(result_type)),
 		ast::make_expr_unary_op(op_kind, std::move(expr))
 	);
 }
@@ -469,7 +469,7 @@ static ast::expression get_type_op_unary_mut(
 		src_tokens,
 		ast::expression_type_kind::type_name,
 		ast::make_typename_typespec(nullptr),
-		ast::constant_value(std::move(result_type)),
+		ast::constant_value_storage(std::move(result_type)),
 		ast::make_expr_unary_op(op_kind, std::move(expr))
 	);
 }
@@ -531,7 +531,7 @@ static ast::expression get_type_op_unary_consteval(
 		src_tokens,
 		ast::expression_type_kind::type_name,
 		ast::make_typename_typespec(nullptr),
-		ast::constant_value(std::move(result_type)),
+		ast::constant_value_storage(std::move(result_type)),
 		ast::make_expr_unary_op(op_kind, std::move(expr))
 	);
 }
@@ -588,7 +588,7 @@ static ast::expression get_type_op_unary_move(
 		src_tokens,
 		ast::expression_type_kind::type_name,
 		ast::make_typename_typespec(nullptr),
-		ast::constant_value(std::move(result_type)),
+		ast::constant_value_storage(std::move(result_type)),
 		ast::make_expr_unary_op(op_kind, std::move(expr))
 	);
 }
@@ -621,7 +621,7 @@ static ast::expression get_builtin_unary_sizeof(
 			src_tokens,
 			ast::expression_type_kind::rvalue,
 			ast::make_base_type_typespec({}, context.get_usize_type_info()),
-			ast::constant_value(size),
+			ast::constant_value_storage(size),
 			ast::make_expr_unary_op(op_kind, std::move(expr))
 		);
 	}
@@ -632,7 +632,7 @@ static ast::expression get_builtin_unary_sizeof(
 			src_tokens,
 			ast::expression_type_kind::rvalue,
 			ast::make_base_type_typespec({}, context.get_usize_type_info()),
-			ast::constant_value(size),
+			ast::constant_value_storage(size),
 			ast::make_expr_unary_op(op_kind, std::move(expr))
 		);
 	}
@@ -655,7 +655,7 @@ static ast::expression get_builtin_unary_sizeof(
 			src_tokens,
 			ast::expression_type_kind::rvalue,
 			ast::make_base_type_typespec({}, context.get_usize_type_info()),
-			ast::constant_value(size),
+			ast::constant_value_storage(size),
 			ast::make_expr_unary_op(op_kind, std::move(expr))
 		);
 	}
@@ -702,7 +702,7 @@ static ast::expression get_builtin_unary_typeof(
 		src_tokens,
 		ast::expression_type_kind::type_name,
 		ast::make_typename_typespec(nullptr),
-		ast::constant_value(std::move(result_type)),
+		ast::constant_value_storage(std::move(result_type)),
 		ast::make_expr_unary_op(op_kind, std::move(expr))
 	);
 }
@@ -1003,7 +1003,7 @@ ast::expression make_builtin_cast(
 			src_tokens,
 			ast::expression_type_kind::rvalue,
 			std::move(dest_t_copy),
-			ast::constant_value::get_null(),
+			ast::constant_value_storage::get_null(),
 			ast::make_expr_cast(std::move(expr), std::move(dest_type))
 		);
 	}
@@ -1121,8 +1121,8 @@ ast::expression make_builtin_cast(
 				)
 				{
 					ast::typespec dest_t_copy = dest_t;
-					ast::constant_value result_value;
-					result_value.emplace<ast::constant_value::sint>(value);
+					ast::constant_value_storage result_value;
+					result_value.emplace<ast::constant_value_storage::sint>(value);
 					return ast::make_constant_expression(
 						src_tokens,
 						ast::expression_type_kind::rvalue,
@@ -1138,8 +1138,8 @@ ast::expression make_builtin_cast(
 				)
 				{
 					ast::typespec dest_t_copy = dest_t;
-					ast::constant_value result_value;
-					result_value.emplace<ast::constant_value::uint>(static_cast<uint64_t>(value));
+					ast::constant_value_storage result_value;
+					result_value.emplace<ast::constant_value_storage::uint>(static_cast<uint64_t>(value));
 					return ast::make_constant_expression(
 						src_tokens,
 						ast::expression_type_kind::rvalue,
@@ -1159,14 +1159,14 @@ ast::expression make_builtin_cast(
 				if (value <= dest_max_value)
 				{
 					ast::typespec dest_t_copy = dest_t;
-					ast::constant_value result_value;
+					ast::constant_value_storage result_value;
 					if (ast::is_signed_integer_kind(dest_kind))
 					{
-						result_value.emplace<ast::constant_value::sint>(static_cast<int64_t>(value));
+						result_value.emplace<ast::constant_value_storage::sint>(static_cast<int64_t>(value));
 					}
 					else
 					{
-						result_value.emplace<ast::constant_value::uint>(static_cast<uint64_t>(value));
+						result_value.emplace<ast::constant_value_storage::uint>(static_cast<uint64_t>(value));
 					}
 					return ast::make_constant_expression(
 						src_tokens,
@@ -1516,7 +1516,7 @@ static ast::expression get_type_op_binary_equals_not_equals(
 		src_tokens,
 		ast::expression_type_kind::rvalue,
 		ast::make_base_type_typespec(src_tokens, context.get_builtin_type_info(ast::type_info::bool_)),
-		ast::constant_value(result),
+		ast::constant_value_storage(result),
 		ast::make_expr_binary_op(op_kind, std::move(lhs), std::move(rhs))
 	);
 }
@@ -2281,7 +2281,7 @@ static ast::typespec get_literal_integer_type(
 static ast::expression make_unary_plus_literal_operation(
 	lex::src_tokens const &src_tokens,
 	ast::literal_kind kind,
-	ast::constant_value const &value,
+	ast::constant_value_storage const &value,
 	parse_context &context
 )
 {
@@ -2300,7 +2300,7 @@ static ast::expression make_unary_plus_literal_operation(
 static ast::expression make_unary_minus_literal_operation(
 	lex::src_tokens const &src_tokens,
 	ast::literal_kind kind,
-	ast::constant_value const &value,
+	ast::constant_value_storage const &value,
 	parse_context &context
 )
 {
@@ -2313,7 +2313,7 @@ static ast::expression make_unary_minus_literal_operation(
 			src_tokens,
 			ast::expression_type_kind::integer_literal,
 			ast::make_base_type_typespec(src_tokens, context.get_builtin_type_info(ast::type_info::uint64_)),
-			ast::constant_value(static_cast<uint64_t>(int64_max) + 1),
+			ast::constant_value_storage(static_cast<uint64_t>(int64_max) + 1),
 			ast::make_expr_integer_literal(kind)
 		);
 	}
@@ -2323,7 +2323,7 @@ static ast::expression make_unary_minus_literal_operation(
 			src_tokens,
 			ast::expression_type_kind::integer_literal,
 			get_literal_integer_type(src_tokens, kind, -int_value, context),
-			ast::constant_value(-int_value),
+			ast::constant_value_storage(-int_value),
 			ast::make_expr_integer_literal(kind)
 		);
 	}
@@ -2353,8 +2353,8 @@ static ast::expression make_binary_plus_literal_operation(
 	lex::src_tokens const &src_tokens,
 	ast::literal_kind lhs_kind,
 	ast::literal_kind rhs_kind,
-	ast::constant_value const &lhs_value,
-	ast::constant_value const &rhs_value,
+	ast::constant_value_storage const &lhs_value,
+	ast::constant_value_storage const &rhs_value,
 	parse_context &context
 )
 {
@@ -2380,7 +2380,7 @@ static ast::expression make_binary_plus_literal_operation(
 				src_tokens,
 				ast::expression_type_kind::integer_literal,
 				get_literal_integer_type(src_tokens, kind, result_value, context),
-				ast::constant_value(result_value),
+				ast::constant_value_storage(result_value),
 				ast::make_expr_integer_literal(kind)
 			);
 		}
@@ -2401,7 +2401,7 @@ static ast::expression make_binary_plus_literal_operation(
 				src_tokens,
 				ast::expression_type_kind::integer_literal,
 				get_literal_integer_type(src_tokens, kind, signed_result_value, context),
-				ast::constant_value(signed_result_value),
+				ast::constant_value_storage(signed_result_value),
 				ast::make_expr_integer_literal(kind)
 			);
 		}
@@ -2418,7 +2418,7 @@ static ast::expression make_binary_plus_literal_operation(
 				src_tokens,
 				ast::expression_type_kind::integer_literal,
 				get_literal_integer_type(src_tokens, kind, unsigned_result_value, context),
-				ast::constant_value(unsigned_result_value),
+				ast::constant_value_storage(unsigned_result_value),
 				ast::make_expr_integer_literal(kind)
 			);
 		}
@@ -2431,8 +2431,8 @@ static ast::expression make_binary_minus_literal_operation(
 	lex::src_tokens const &src_tokens,
 	ast::literal_kind lhs_kind,
 	ast::literal_kind rhs_kind,
-	ast::constant_value const &lhs_value,
-	ast::constant_value const &rhs_value,
+	ast::constant_value_storage const &lhs_value,
+	ast::constant_value_storage const &rhs_value,
 	parse_context &context
 )
 {
@@ -2458,7 +2458,7 @@ static ast::expression make_binary_minus_literal_operation(
 				src_tokens,
 				ast::expression_type_kind::integer_literal,
 				get_literal_integer_type(src_tokens, kind, unsigned_result_value, context),
-				ast::constant_value(unsigned_result_value),
+				ast::constant_value_storage(unsigned_result_value),
 				ast::make_expr_integer_literal(kind)
 			);
 		}
@@ -2474,7 +2474,7 @@ static ast::expression make_binary_minus_literal_operation(
 				src_tokens,
 				ast::expression_type_kind::integer_literal,
 				get_literal_integer_type(src_tokens, kind, signed_result_value, context),
-				ast::constant_value(signed_result_value),
+				ast::constant_value_storage(signed_result_value),
 				ast::make_expr_integer_literal(kind)
 			);
 		}
@@ -2495,7 +2495,7 @@ static ast::expression make_binary_minus_literal_operation(
 				src_tokens,
 				ast::expression_type_kind::integer_literal,
 				get_literal_integer_type(src_tokens, kind, signed_result_value, context),
-				ast::constant_value(signed_result_value),
+				ast::constant_value_storage(signed_result_value),
 				ast::make_expr_integer_literal(kind)
 			);
 		}
@@ -2511,7 +2511,7 @@ static ast::expression make_binary_minus_literal_operation(
 				src_tokens,
 				ast::expression_type_kind::integer_literal,
 				get_literal_integer_type(src_tokens, kind, unsigned_result_value, context),
-				ast::constant_value(unsigned_result_value),
+				ast::constant_value_storage(unsigned_result_value),
 				ast::make_expr_integer_literal(kind)
 			);
 		}
@@ -2524,8 +2524,8 @@ static ast::expression make_binary_multiply_literal_operation(
 	lex::src_tokens const &src_tokens,
 	ast::literal_kind lhs_kind,
 	ast::literal_kind rhs_kind,
-	ast::constant_value const &lhs_value,
-	ast::constant_value const &rhs_value,
+	ast::constant_value_storage const &lhs_value,
+	ast::constant_value_storage const &rhs_value,
 	parse_context &context
 )
 {
@@ -2551,7 +2551,7 @@ static ast::expression make_binary_multiply_literal_operation(
 				src_tokens,
 				ast::expression_type_kind::integer_literal,
 				get_literal_integer_type(src_tokens, kind, result_value, context),
-				ast::constant_value(result_value),
+				ast::constant_value_storage(result_value),
 				ast::make_expr_integer_literal(kind)
 			);
 		}
@@ -2572,7 +2572,7 @@ static ast::expression make_binary_multiply_literal_operation(
 				src_tokens,
 				ast::expression_type_kind::integer_literal,
 				get_literal_integer_type(src_tokens, kind, signed_result_value, context),
-				ast::constant_value(signed_result_value),
+				ast::constant_value_storage(signed_result_value),
 				ast::make_expr_integer_literal(kind)
 			);
 		}
@@ -2588,7 +2588,7 @@ static ast::expression make_binary_multiply_literal_operation(
 				src_tokens,
 				ast::expression_type_kind::integer_literal,
 				get_literal_integer_type(src_tokens, kind, unsigned_result_value, context),
-				ast::constant_value(unsigned_result_value),
+				ast::constant_value_storage(unsigned_result_value),
 				ast::make_expr_integer_literal(kind)
 			);
 		}
@@ -2601,8 +2601,8 @@ static ast::expression make_binary_divide_literal_operation(
 	lex::src_tokens const &src_tokens,
 	ast::literal_kind lhs_kind,
 	ast::literal_kind rhs_kind,
-	ast::constant_value const &lhs_value,
-	ast::constant_value const &rhs_value,
+	ast::constant_value_storage const &lhs_value,
+	ast::constant_value_storage const &rhs_value,
 	parse_context &context
 )
 {
@@ -2628,7 +2628,7 @@ static ast::expression make_binary_divide_literal_operation(
 				src_tokens,
 				ast::expression_type_kind::integer_literal,
 				get_literal_integer_type(src_tokens, kind, result_value, context),
-				ast::constant_value(result_value),
+				ast::constant_value_storage(result_value),
 				ast::make_expr_integer_literal(kind)
 			);
 		}
@@ -2649,7 +2649,7 @@ static ast::expression make_binary_divide_literal_operation(
 				src_tokens,
 				ast::expression_type_kind::integer_literal,
 				get_literal_integer_type(src_tokens, kind, signed_result_value, context),
-				ast::constant_value(signed_result_value),
+				ast::constant_value_storage(signed_result_value),
 				ast::make_expr_integer_literal(kind)
 			);
 		}
@@ -2665,7 +2665,7 @@ static ast::expression make_binary_divide_literal_operation(
 				src_tokens,
 				ast::expression_type_kind::integer_literal,
 				get_literal_integer_type(src_tokens, kind, unsigned_result_value, context),
-				ast::constant_value(unsigned_result_value),
+				ast::constant_value_storage(unsigned_result_value),
 				ast::make_expr_integer_literal(kind)
 			);
 		}
@@ -2678,8 +2678,8 @@ static ast::expression make_binary_modulo_literal_operation(
 	lex::src_tokens const &src_tokens,
 	ast::literal_kind lhs_kind,
 	ast::literal_kind rhs_kind,
-	ast::constant_value const &lhs_value,
-	ast::constant_value const &rhs_value,
+	ast::constant_value_storage const &lhs_value,
+	ast::constant_value_storage const &rhs_value,
 	parse_context &context
 )
 {
@@ -2710,7 +2710,7 @@ static ast::expression make_binary_modulo_literal_operation(
 				src_tokens,
 				ast::expression_type_kind::integer_literal,
 				get_literal_integer_type(src_tokens, kind, result_value, context),
-				ast::constant_value(result_value),
+				ast::constant_value_storage(result_value),
 				ast::make_expr_integer_literal(kind)
 			);
 		}
@@ -2734,7 +2734,7 @@ static ast::expression make_binary_modulo_literal_operation(
 				src_tokens,
 				ast::expression_type_kind::integer_literal,
 				get_literal_integer_type(src_tokens, kind, result_value, context),
-				ast::constant_value(result_value),
+				ast::constant_value_storage(result_value),
 				ast::make_expr_integer_literal(kind)
 			);
 		}

--- a/src/ctx/builtin_operators.cpp
+++ b/src/ctx/builtin_operators.cpp
@@ -22,13 +22,13 @@ static auto get_base_kinds(
 	};
 };
 
-template<size_t kind>
+template<ast::constant_value_kind kind>
 static auto get_constant_expression_values(
 	ast::expression const &lhs,
 	ast::expression const &rhs
 )
 {
-	static_assert(kind != ast::constant_value_storage::aggregate);
+	static_assert(kind != ast::constant_value_kind::aggregate);
 	bz_assert(lhs.is_constant());
 	bz_assert(rhs.is_constant());
 	auto const &lhs_value = lhs.get_constant_value();
@@ -36,7 +36,7 @@ static auto get_constant_expression_values(
 	bz_assert(lhs_value.kind() == kind);
 	bz_assert(rhs_value.kind() == kind);
 
-	if constexpr (kind == ast::constant_value_storage::string)
+	if constexpr (kind == ast::constant_value_kind::string)
 	{
 		return std::make_pair(
 			lhs_value.get_string(),
@@ -1122,7 +1122,7 @@ ast::expression make_builtin_cast(
 				{
 					ast::typespec dest_t_copy = dest_t;
 					ast::constant_value_storage result_value;
-					result_value.emplace<ast::constant_value_storage::sint>(value);
+					result_value.emplace<ast::constant_value_kind::sint>(value);
 					return ast::make_constant_expression(
 						src_tokens,
 						ast::expression_type_kind::rvalue,
@@ -1139,7 +1139,7 @@ ast::expression make_builtin_cast(
 				{
 					ast::typespec dest_t_copy = dest_t;
 					ast::constant_value_storage result_value;
-					result_value.emplace<ast::constant_value_storage::uint>(static_cast<uint64_t>(value));
+					result_value.emplace<ast::constant_value_kind::uint>(static_cast<uint64_t>(value));
 					return ast::make_constant_expression(
 						src_tokens,
 						ast::expression_type_kind::rvalue,
@@ -1162,11 +1162,11 @@ ast::expression make_builtin_cast(
 					ast::constant_value_storage result_value;
 					if (ast::is_signed_integer_kind(dest_kind))
 					{
-						result_value.emplace<ast::constant_value_storage::sint>(static_cast<int64_t>(value));
+						result_value.emplace<ast::constant_value_kind::sint>(static_cast<int64_t>(value));
 					}
 					else
 					{
-						result_value.emplace<ast::constant_value_storage::uint>(static_cast<uint64_t>(value));
+						result_value.emplace<ast::constant_value_kind::uint>(static_cast<uint64_t>(value));
 					}
 					return ast::make_constant_expression(
 						src_tokens,

--- a/src/ctx/builtin_operators.cpp
+++ b/src/ctx/builtin_operators.cpp
@@ -143,7 +143,7 @@ static ast::expression get_type_op_unary_reference(
 		src_tokens,
 		ast::expression_type_kind::type_name,
 		ast::make_typename_typespec(nullptr),
-		ast::constant_value_storage(std::move(result_type)),
+		context.add_constant_type(std::move(result_type)),
 		ast::make_expr_unary_op(op_kind, std::move(expr))
 	);
 }
@@ -200,7 +200,7 @@ static ast::expression get_type_op_unary_auto_ref(
 		src_tokens,
 		ast::expression_type_kind::type_name,
 		ast::make_typename_typespec(nullptr),
-		ast::constant_value_storage(std::move(result_type)),
+		context.add_constant_type(std::move(result_type)),
 		ast::make_expr_unary_op(op_kind, std::move(expr))
 	);
 }
@@ -269,7 +269,7 @@ static ast::expression get_type_op_unary_auto_ref_const(
 		src_tokens,
 		ast::expression_type_kind::type_name,
 		ast::make_typename_typespec(nullptr),
-		ast::constant_value_storage(std::move(result_type)),
+		context.add_constant_type(std::move(result_type)),
 		ast::make_expr_unary_op(op_kind, std::move(expr))
 	);
 }
@@ -325,7 +325,7 @@ static ast::expression get_type_op_unary_pointer(
 		src_tokens,
 		ast::expression_type_kind::type_name,
 		ast::make_typename_typespec(nullptr),
-		ast::constant_value_storage(std::move(result_type)),
+		context.add_constant_type(std::move(result_type)),
 		ast::make_expr_unary_op(op_kind, std::move(expr))
 	);
 }
@@ -376,7 +376,7 @@ static ast::expression get_type_op_unary_question_mark(
 		src_tokens,
 		ast::expression_type_kind::type_name,
 		ast::make_typename_typespec(nullptr),
-		ast::constant_value_storage(std::move(result_type)),
+		context.add_constant_type(std::move(result_type)),
 		ast::make_expr_unary_op(op_kind, std::move(expr))
 	);
 }
@@ -407,7 +407,7 @@ static ast::expression get_type_op_unary_dot_dot_dot(
 		src_tokens,
 		ast::expression_type_kind::type_name,
 		ast::make_typename_typespec(nullptr),
-		ast::constant_value_storage(std::move(result_type)),
+		context.add_constant_type(std::move(result_type)),
 		ast::make_expr_unary_op(op_kind, std::move(expr))
 	);
 }
@@ -469,7 +469,7 @@ static ast::expression get_type_op_unary_mut(
 		src_tokens,
 		ast::expression_type_kind::type_name,
 		ast::make_typename_typespec(nullptr),
-		ast::constant_value_storage(std::move(result_type)),
+		context.add_constant_type(std::move(result_type)),
 		ast::make_expr_unary_op(op_kind, std::move(expr))
 	);
 }
@@ -531,7 +531,7 @@ static ast::expression get_type_op_unary_consteval(
 		src_tokens,
 		ast::expression_type_kind::type_name,
 		ast::make_typename_typespec(nullptr),
-		ast::constant_value_storage(std::move(result_type)),
+		context.add_constant_type(std::move(result_type)),
 		ast::make_expr_unary_op(op_kind, std::move(expr))
 	);
 }
@@ -588,7 +588,7 @@ static ast::expression get_type_op_unary_move(
 		src_tokens,
 		ast::expression_type_kind::type_name,
 		ast::make_typename_typespec(nullptr),
-		ast::constant_value_storage(std::move(result_type)),
+		context.add_constant_type(std::move(result_type)),
 		ast::make_expr_unary_op(op_kind, std::move(expr))
 	);
 }
@@ -605,7 +605,7 @@ static ast::expression get_builtin_unary_sizeof(
 
 	if (expr.is_typename())
 	{
-		auto const type = expr.get_typename().as_typespec_view();
+		auto const type = expr.get_typename();
 		if (!ast::is_complete(type))
 		{
 			context.report_error(src_tokens, bz::format("cannot take 'sizeof' of an incomplete type '{}'", type));
@@ -621,18 +621,18 @@ static ast::expression get_builtin_unary_sizeof(
 			src_tokens,
 			ast::expression_type_kind::rvalue,
 			ast::make_base_type_typespec({}, context.get_usize_type_info()),
-			ast::constant_value_storage(size),
+			ast::constant_value(size),
 			ast::make_expr_unary_op(op_kind, std::move(expr))
 		);
 	}
 	else if (expr.is<ast::expanded_variadic_expression>())
 	{
-		auto const size = expr.get<ast::expanded_variadic_expression>().exprs.size();
+		uint64_t const size = expr.get<ast::expanded_variadic_expression>().exprs.size();
 		return ast::make_constant_expression(
 			src_tokens,
 			ast::expression_type_kind::rvalue,
 			ast::make_base_type_typespec({}, context.get_usize_type_info()),
-			ast::constant_value_storage(size),
+			ast::constant_value(size),
 			ast::make_expr_unary_op(op_kind, std::move(expr))
 		);
 	}
@@ -650,12 +650,12 @@ static ast::expression get_builtin_unary_sizeof(
 			context.report_error(src_tokens, bz::format("cannot take 'sizeof' of an expression with non-instantiable type '{}'", type));
 			return ast::make_error_expression(src_tokens, ast::make_expr_unary_op(op_kind, std::move(expr)));
 		}
-		auto const size = context.get_sizeof(type);
+		uint64_t const size = context.get_sizeof(type);
 		return ast::make_constant_expression(
 			src_tokens,
 			ast::expression_type_kind::rvalue,
 			ast::make_base_type_typespec({}, context.get_usize_type_info()),
-			ast::constant_value_storage(size),
+			ast::constant_value(size),
 			ast::make_expr_unary_op(op_kind, std::move(expr))
 		);
 	}
@@ -702,7 +702,7 @@ static ast::expression get_builtin_unary_typeof(
 		src_tokens,
 		ast::expression_type_kind::type_name,
 		ast::make_typename_typespec(nullptr),
-		ast::constant_value_storage(std::move(result_type)),
+		context.add_constant_type(std::move(result_type)),
 		ast::make_expr_unary_op(op_kind, std::move(expr))
 	);
 }
@@ -1003,7 +1003,7 @@ ast::expression make_builtin_cast(
 			src_tokens,
 			ast::expression_type_kind::rvalue,
 			std::move(dest_t_copy),
-			ast::constant_value_storage::get_null(),
+			ast::constant_value::get_null(),
 			ast::make_expr_cast(std::move(expr), std::move(dest_type))
 		);
 	}
@@ -1121,13 +1121,11 @@ ast::expression make_builtin_cast(
 				)
 				{
 					ast::typespec dest_t_copy = dest_t;
-					ast::constant_value_storage result_value;
-					result_value.emplace<ast::constant_value_kind::sint>(value);
 					return ast::make_constant_expression(
 						src_tokens,
 						ast::expression_type_kind::rvalue,
 						std::move(dest_t_copy),
-						std::move(result_value),
+						ast::constant_value(value),
 						ast::make_expr_cast(std::move(expr), std::move(dest_type))
 					);
 				}
@@ -1138,13 +1136,11 @@ ast::expression make_builtin_cast(
 				)
 				{
 					ast::typespec dest_t_copy = dest_t;
-					ast::constant_value_storage result_value;
-					result_value.emplace<ast::constant_value_kind::uint>(static_cast<uint64_t>(value));
 					return ast::make_constant_expression(
 						src_tokens,
 						ast::expression_type_kind::rvalue,
 						std::move(dest_t_copy),
-						std::move(result_value),
+						ast::constant_value(static_cast<uint64_t>(value)),
 						ast::make_expr_cast(std::move(expr), std::move(dest_type))
 					);
 				}
@@ -1159,7 +1155,7 @@ ast::expression make_builtin_cast(
 				if (value <= dest_max_value)
 				{
 					ast::typespec dest_t_copy = dest_t;
-					ast::constant_value_storage result_value;
+					ast::constant_value result_value;
 					if (ast::is_signed_integer_kind(dest_kind))
 					{
 						result_value.emplace<ast::constant_value_kind::sint>(static_cast<int64_t>(value));
@@ -1484,8 +1480,8 @@ static ast::expression get_type_op_binary_equals_not_equals(
 
 	auto const op_str = token_info[op_kind].token_value;
 
-	auto &lhs_type = lhs.get_typename();
-	auto &rhs_type = rhs.get_typename();
+	auto const lhs_type = lhs.get_typename();
+	auto const rhs_type = rhs.get_typename();
 
 	bool good = true;
 	if (!ast::is_complete(lhs_type))
@@ -1516,7 +1512,7 @@ static ast::expression get_type_op_binary_equals_not_equals(
 		src_tokens,
 		ast::expression_type_kind::rvalue,
 		ast::make_base_type_typespec(src_tokens, context.get_builtin_type_info(ast::type_info::bool_)),
-		ast::constant_value_storage(result),
+		ast::constant_value(result),
 		ast::make_expr_binary_op(op_kind, std::move(lhs), std::move(rhs))
 	);
 }
@@ -2281,7 +2277,7 @@ static ast::typespec get_literal_integer_type(
 static ast::expression make_unary_plus_literal_operation(
 	lex::src_tokens const &src_tokens,
 	ast::literal_kind kind,
-	ast::constant_value_storage const &value,
+	ast::constant_value const &value,
 	parse_context &context
 )
 {
@@ -2300,7 +2296,7 @@ static ast::expression make_unary_plus_literal_operation(
 static ast::expression make_unary_minus_literal_operation(
 	lex::src_tokens const &src_tokens,
 	ast::literal_kind kind,
-	ast::constant_value_storage const &value,
+	ast::constant_value const &value,
 	parse_context &context
 )
 {
@@ -2313,7 +2309,7 @@ static ast::expression make_unary_minus_literal_operation(
 			src_tokens,
 			ast::expression_type_kind::integer_literal,
 			ast::make_base_type_typespec(src_tokens, context.get_builtin_type_info(ast::type_info::uint64_)),
-			ast::constant_value_storage(static_cast<uint64_t>(int64_max) + 1),
+			ast::constant_value(static_cast<uint64_t>(int64_max) + 1),
 			ast::make_expr_integer_literal(kind)
 		);
 	}
@@ -2323,7 +2319,7 @@ static ast::expression make_unary_minus_literal_operation(
 			src_tokens,
 			ast::expression_type_kind::integer_literal,
 			get_literal_integer_type(src_tokens, kind, -int_value, context),
-			ast::constant_value_storage(-int_value),
+			ast::constant_value(-int_value),
 			ast::make_expr_integer_literal(kind)
 		);
 	}
@@ -2353,8 +2349,8 @@ static ast::expression make_binary_plus_literal_operation(
 	lex::src_tokens const &src_tokens,
 	ast::literal_kind lhs_kind,
 	ast::literal_kind rhs_kind,
-	ast::constant_value_storage const &lhs_value,
-	ast::constant_value_storage const &rhs_value,
+	ast::constant_value const &lhs_value,
+	ast::constant_value const &rhs_value,
 	parse_context &context
 )
 {
@@ -2380,7 +2376,7 @@ static ast::expression make_binary_plus_literal_operation(
 				src_tokens,
 				ast::expression_type_kind::integer_literal,
 				get_literal_integer_type(src_tokens, kind, result_value, context),
-				ast::constant_value_storage(result_value),
+				ast::constant_value(result_value),
 				ast::make_expr_integer_literal(kind)
 			);
 		}
@@ -2401,7 +2397,7 @@ static ast::expression make_binary_plus_literal_operation(
 				src_tokens,
 				ast::expression_type_kind::integer_literal,
 				get_literal_integer_type(src_tokens, kind, signed_result_value, context),
-				ast::constant_value_storage(signed_result_value),
+				ast::constant_value(signed_result_value),
 				ast::make_expr_integer_literal(kind)
 			);
 		}
@@ -2418,7 +2414,7 @@ static ast::expression make_binary_plus_literal_operation(
 				src_tokens,
 				ast::expression_type_kind::integer_literal,
 				get_literal_integer_type(src_tokens, kind, unsigned_result_value, context),
-				ast::constant_value_storage(unsigned_result_value),
+				ast::constant_value(unsigned_result_value),
 				ast::make_expr_integer_literal(kind)
 			);
 		}
@@ -2431,8 +2427,8 @@ static ast::expression make_binary_minus_literal_operation(
 	lex::src_tokens const &src_tokens,
 	ast::literal_kind lhs_kind,
 	ast::literal_kind rhs_kind,
-	ast::constant_value_storage const &lhs_value,
-	ast::constant_value_storage const &rhs_value,
+	ast::constant_value const &lhs_value,
+	ast::constant_value const &rhs_value,
 	parse_context &context
 )
 {
@@ -2458,7 +2454,7 @@ static ast::expression make_binary_minus_literal_operation(
 				src_tokens,
 				ast::expression_type_kind::integer_literal,
 				get_literal_integer_type(src_tokens, kind, unsigned_result_value, context),
-				ast::constant_value_storage(unsigned_result_value),
+				ast::constant_value(unsigned_result_value),
 				ast::make_expr_integer_literal(kind)
 			);
 		}
@@ -2474,7 +2470,7 @@ static ast::expression make_binary_minus_literal_operation(
 				src_tokens,
 				ast::expression_type_kind::integer_literal,
 				get_literal_integer_type(src_tokens, kind, signed_result_value, context),
-				ast::constant_value_storage(signed_result_value),
+				ast::constant_value(signed_result_value),
 				ast::make_expr_integer_literal(kind)
 			);
 		}
@@ -2495,7 +2491,7 @@ static ast::expression make_binary_minus_literal_operation(
 				src_tokens,
 				ast::expression_type_kind::integer_literal,
 				get_literal_integer_type(src_tokens, kind, signed_result_value, context),
-				ast::constant_value_storage(signed_result_value),
+				ast::constant_value(signed_result_value),
 				ast::make_expr_integer_literal(kind)
 			);
 		}
@@ -2511,7 +2507,7 @@ static ast::expression make_binary_minus_literal_operation(
 				src_tokens,
 				ast::expression_type_kind::integer_literal,
 				get_literal_integer_type(src_tokens, kind, unsigned_result_value, context),
-				ast::constant_value_storage(unsigned_result_value),
+				ast::constant_value(unsigned_result_value),
 				ast::make_expr_integer_literal(kind)
 			);
 		}
@@ -2524,8 +2520,8 @@ static ast::expression make_binary_multiply_literal_operation(
 	lex::src_tokens const &src_tokens,
 	ast::literal_kind lhs_kind,
 	ast::literal_kind rhs_kind,
-	ast::constant_value_storage const &lhs_value,
-	ast::constant_value_storage const &rhs_value,
+	ast::constant_value const &lhs_value,
+	ast::constant_value const &rhs_value,
 	parse_context &context
 )
 {
@@ -2551,7 +2547,7 @@ static ast::expression make_binary_multiply_literal_operation(
 				src_tokens,
 				ast::expression_type_kind::integer_literal,
 				get_literal_integer_type(src_tokens, kind, result_value, context),
-				ast::constant_value_storage(result_value),
+				ast::constant_value(result_value),
 				ast::make_expr_integer_literal(kind)
 			);
 		}
@@ -2572,7 +2568,7 @@ static ast::expression make_binary_multiply_literal_operation(
 				src_tokens,
 				ast::expression_type_kind::integer_literal,
 				get_literal_integer_type(src_tokens, kind, signed_result_value, context),
-				ast::constant_value_storage(signed_result_value),
+				ast::constant_value(signed_result_value),
 				ast::make_expr_integer_literal(kind)
 			);
 		}
@@ -2588,7 +2584,7 @@ static ast::expression make_binary_multiply_literal_operation(
 				src_tokens,
 				ast::expression_type_kind::integer_literal,
 				get_literal_integer_type(src_tokens, kind, unsigned_result_value, context),
-				ast::constant_value_storage(unsigned_result_value),
+				ast::constant_value(unsigned_result_value),
 				ast::make_expr_integer_literal(kind)
 			);
 		}
@@ -2601,8 +2597,8 @@ static ast::expression make_binary_divide_literal_operation(
 	lex::src_tokens const &src_tokens,
 	ast::literal_kind lhs_kind,
 	ast::literal_kind rhs_kind,
-	ast::constant_value_storage const &lhs_value,
-	ast::constant_value_storage const &rhs_value,
+	ast::constant_value const &lhs_value,
+	ast::constant_value const &rhs_value,
 	parse_context &context
 )
 {
@@ -2628,7 +2624,7 @@ static ast::expression make_binary_divide_literal_operation(
 				src_tokens,
 				ast::expression_type_kind::integer_literal,
 				get_literal_integer_type(src_tokens, kind, result_value, context),
-				ast::constant_value_storage(result_value),
+				ast::constant_value(result_value),
 				ast::make_expr_integer_literal(kind)
 			);
 		}
@@ -2649,7 +2645,7 @@ static ast::expression make_binary_divide_literal_operation(
 				src_tokens,
 				ast::expression_type_kind::integer_literal,
 				get_literal_integer_type(src_tokens, kind, signed_result_value, context),
-				ast::constant_value_storage(signed_result_value),
+				ast::constant_value(signed_result_value),
 				ast::make_expr_integer_literal(kind)
 			);
 		}
@@ -2665,7 +2661,7 @@ static ast::expression make_binary_divide_literal_operation(
 				src_tokens,
 				ast::expression_type_kind::integer_literal,
 				get_literal_integer_type(src_tokens, kind, unsigned_result_value, context),
-				ast::constant_value_storage(unsigned_result_value),
+				ast::constant_value(unsigned_result_value),
 				ast::make_expr_integer_literal(kind)
 			);
 		}
@@ -2678,8 +2674,8 @@ static ast::expression make_binary_modulo_literal_operation(
 	lex::src_tokens const &src_tokens,
 	ast::literal_kind lhs_kind,
 	ast::literal_kind rhs_kind,
-	ast::constant_value_storage const &lhs_value,
-	ast::constant_value_storage const &rhs_value,
+	ast::constant_value const &lhs_value,
+	ast::constant_value const &rhs_value,
 	parse_context &context
 )
 {
@@ -2710,7 +2706,7 @@ static ast::expression make_binary_modulo_literal_operation(
 				src_tokens,
 				ast::expression_type_kind::integer_literal,
 				get_literal_integer_type(src_tokens, kind, result_value, context),
-				ast::constant_value_storage(result_value),
+				ast::constant_value(result_value),
 				ast::make_expr_integer_literal(kind)
 			);
 		}
@@ -2734,7 +2730,7 @@ static ast::expression make_binary_modulo_literal_operation(
 				src_tokens,
 				ast::expression_type_kind::integer_literal,
 				get_literal_integer_type(src_tokens, kind, result_value, context),
-				ast::constant_value_storage(result_value),
+				ast::constant_value(result_value),
 				ast::make_expr_integer_literal(kind)
 			);
 		}

--- a/src/ctx/global_context.cpp
+++ b/src/ctx/global_context.cpp
@@ -992,6 +992,66 @@ size_t global_context::get_pointer_size(void) const
 	return this->comptime_codegen_context->machine_parameters.pointer_size;
 }
 
+ast::constant_value global_context::add_constant_string(bz::u8string str)
+{
+	auto const &s = this->constant_string_storage.push_back(std::move(str));
+	return ast::constant_value(s.as_string_view());
+}
+
+ast::constant_value global_context::add_constant_array(ast::arena_vector<ast::constant_value_storage> elems)
+{
+	auto const &arr = this->constant_aggregate_storage.push_back(std::move(elems));
+	ast::constant_value result;
+	result.emplace<ast::constant_value_kind::array>(arr.as_array_view());
+	return result;
+}
+
+ast::constant_value global_context::add_constant_tuple(ast::arena_vector<ast::constant_value_storage> elems)
+{
+	auto const &arr = this->constant_aggregate_storage.push_back(std::move(elems));
+	ast::constant_value result;
+	result.emplace<ast::constant_value_kind::tuple>(arr.as_array_view());
+	return result;
+}
+
+ast::constant_value global_context::add_constant_aggregate(ast::arena_vector<ast::constant_value_storage> elems)
+{
+	auto const &arr = this->constant_aggregate_storage.push_back(std::move(elems));
+	ast::constant_value result;
+	result.emplace<ast::constant_value_kind::aggregate>(arr.as_array_view());
+	return result;
+}
+
+ast::constant_value global_context::add_constant_sint_array(ast::arena_vector<int64_t> elems)
+{
+	auto const &arr = this->constant_sint_array_storage.push_back(std::move(elems));
+	return ast::constant_value(arr.as_array_view());
+}
+
+ast::constant_value global_context::add_constant_uint_array(ast::arena_vector<uint64_t> elems)
+{
+	auto const &arr = this->constant_uint_array_storage.push_back(std::move(elems));
+	return ast::constant_value(arr.as_array_view());
+}
+
+ast::constant_value global_context::add_constant_float32_array(ast::arena_vector<float32_t> elems)
+{
+	auto const &arr = this->constant_float32_array_storage.push_back(std::move(elems));
+	return ast::constant_value(arr.as_array_view());
+}
+
+ast::constant_value global_context::add_constant_float64_array(ast::arena_vector<float64_t> elems)
+{
+	auto const &arr = this->constant_float64_array_storage.push_back(std::move(elems));
+	return ast::constant_value(arr.as_array_view());
+}
+
+ast::constant_value global_context::add_constant_type(ast::typespec type)
+{
+	auto const &t = this->constant_type_storage.push_back(std::move(type));
+	return ast::constant_value(t.as_typespec_view());
+}
+
 bool global_context::is_aggressive_consteval_enabled(void) const
 {
 	auto const &optimizations = ctcli::option_value<ctcli::option("--opt")>;

--- a/src/ctx/global_context.h
+++ b/src/ctx/global_context.h
@@ -176,13 +176,14 @@ struct global_context
 	bz::vector<std::unique_ptr<char[]>> _src_scope_fragments;
 	bz::vector<bz::vector<bz::u8string_view>> _src_scopes_storage;
 
-	bz::vector<bz::u8string>                                   constant_string_storage;
-	bz::vector<ast::arena_vector<ast::constant_value_storage>> constant_aggregate_storage;
-	bz::vector<ast::arena_vector<int64_t>>                     constant_sint_array_storage;
-	bz::vector<ast::arena_vector<uint64_t>>                    constant_uint_array_storage;
-	bz::vector<ast::arena_vector<float32_t>>                   constant_float32_array_storage;
-	bz::vector<ast::arena_vector<float64_t>>                   constant_float64_array_storage;
-	bz::vector<ast::typespec>                                  constant_type_storage;
+	bz::vector<bz::fixed_vector<char>>                 constant_string_storage;
+	bz::vector<ast::arena_vector<ast::constant_value>> constant_aggregate_storage;
+	bz::vector<ast::arena_vector<int64_t>>             constant_sint_array_storage;
+	bz::vector<ast::arena_vector<uint64_t>>            constant_uint_array_storage;
+	bz::vector<ast::arena_vector<float32_t>>           constant_float32_array_storage;
+	bz::vector<ast::arena_vector<float64_t>>           constant_float64_array_storage;
+	bz::vector<ast::typespec>                          constant_type_storage;
+	ast::typespec_view cached_auto_type;
 
 	std::unique_ptr<ast::type_prototype_set_t> type_prototype_set = nullptr;
 
@@ -290,10 +291,10 @@ struct global_context
 	ast::type_info *get_isize_type_info_for_builtin_alias(void) const;
 	size_t get_pointer_size(void) const;
 
-	ast::constant_value add_constant_string(bz::u8string str);
-	ast::constant_value add_constant_array(ast::arena_vector<ast::constant_value_storage> elems);
-	ast::constant_value add_constant_tuple(ast::arena_vector<ast::constant_value_storage> elems);
-	ast::constant_value add_constant_aggregate(ast::arena_vector<ast::constant_value_storage> elems);
+	ast::constant_value add_constant_string(bz::u8string_view str);
+	ast::constant_value add_constant_array(ast::arena_vector<ast::constant_value> elems);
+	ast::constant_value add_constant_tuple(ast::arena_vector<ast::constant_value> elems);
+	ast::constant_value add_constant_aggregate(ast::arena_vector<ast::constant_value> elems);
 	ast::constant_value add_constant_sint_array(ast::arena_vector<int64_t> elems);
 	ast::constant_value add_constant_uint_array(ast::arena_vector<uint64_t> elems);
 	ast::constant_value add_constant_float32_array(ast::arena_vector<float32_t> elems);

--- a/src/ctx/global_context.h
+++ b/src/ctx/global_context.h
@@ -176,6 +176,14 @@ struct global_context
 	bz::vector<std::unique_ptr<char[]>> _src_scope_fragments;
 	bz::vector<bz::vector<bz::u8string_view>> _src_scopes_storage;
 
+	bz::vector<bz::u8string>                                   constant_string_storage;
+	bz::vector<ast::arena_vector<ast::constant_value_storage>> constant_aggregate_storage;
+	bz::vector<ast::arena_vector<int64_t>>                     constant_sint_array_storage;
+	bz::vector<ast::arena_vector<uint64_t>>                    constant_uint_array_storage;
+	bz::vector<ast::arena_vector<float32_t>>                   constant_float32_array_storage;
+	bz::vector<ast::arena_vector<float64_t>>                   constant_float64_array_storage;
+	bz::vector<ast::typespec>                                  constant_type_storage;
+
 	std::unique_ptr<ast::type_prototype_set_t> type_prototype_set = nullptr;
 
 	codegen::target_triple target_triple;
@@ -281,6 +289,16 @@ struct global_context
 	ast::type_info *get_usize_type_info_for_builtin_alias(void) const;
 	ast::type_info *get_isize_type_info_for_builtin_alias(void) const;
 	size_t get_pointer_size(void) const;
+
+	ast::constant_value add_constant_string(bz::u8string str);
+	ast::constant_value add_constant_array(ast::arena_vector<ast::constant_value_storage> elems);
+	ast::constant_value add_constant_tuple(ast::arena_vector<ast::constant_value_storage> elems);
+	ast::constant_value add_constant_aggregate(ast::arena_vector<ast::constant_value_storage> elems);
+	ast::constant_value add_constant_sint_array(ast::arena_vector<int64_t> elems);
+	ast::constant_value add_constant_uint_array(ast::arena_vector<uint64_t> elems);
+	ast::constant_value add_constant_float32_array(ast::arena_vector<float32_t> elems);
+	ast::constant_value add_constant_float64_array(ast::arena_vector<float64_t> elems);
+	ast::constant_value add_constant_type(ast::typespec type);
 
 	bool is_aggressive_consteval_enabled(void) const;
 	bz::optional<uint32_t> get_machine_code_opt_level(void) const;

--- a/src/ctx/parse_context.cpp
+++ b/src/ctx/parse_context.cpp
@@ -1554,7 +1554,7 @@ static ast::expression make_variable_expression(
 		return ast::make_constant_expression(
 			src_tokens,
 			ast::expression_type_kind::type_name, ast::make_typename_typespec(nullptr),
-			ast::constant_value(init_expr.get_typename()),
+			ast::constant_value_storage(init_expr.get_typename()),
 			std::move(result_expr)
 		);
 	}
@@ -1618,7 +1618,7 @@ static ast::expression make_function_name_expression(
 		return ast::make_constant_expression(
 			src_tokens,
 			ast::expression_type_kind::function_name, ast::typespec(),
-			ast::constant_value(),
+			ast::constant_value_storage(),
 			ast::make_expr_function_name(std::move(id), func_decl)
 		);
 	}
@@ -1627,7 +1627,7 @@ static ast::expression make_function_name_expression(
 		return ast::make_constant_expression(
 			src_tokens,
 			ast::expression_type_kind::function_name, get_function_type(func_decl->body),
-			ast::constant_value(&func_decl->body),
+			ast::constant_value_storage(&func_decl->body),
 			ast::make_expr_function_name(std::move(id), func_decl)
 		);
 	}
@@ -1645,7 +1645,7 @@ static ast::expression make_function_name_expression(
 		return ast::make_constant_expression(
 			src_tokens,
 			ast::expression_type_kind::function_alias_name, get_function_type(decl->body),
-			ast::constant_value(&decl->body),
+			ast::constant_value_storage(&decl->body),
 			ast::make_expr_function_alias_name(std::move(id), alias_decl)
 		);
 	}
@@ -1654,7 +1654,7 @@ static ast::expression make_function_name_expression(
 		return ast::make_constant_expression(
 			src_tokens,
 			ast::expression_type_kind::function_alias_name, ast::typespec(),
-			ast::constant_value(),
+			ast::constant_value_storage(),
 			ast::make_expr_function_alias_name(std::move(id), alias_decl)
 		);
 	}
@@ -1689,7 +1689,7 @@ static ast::expression make_function_name_expression(
 		return ast::make_constant_expression(
 			src_tokens,
 			ast::expression_type_kind::function_overload_set, ast::typespec(),
-			ast::constant_value(),
+			ast::constant_value_storage(),
 			ast::make_expr_function_overload_set(std::move(id), std::move(set))
 		);
 	}
@@ -1715,7 +1715,7 @@ static ast::expression make_type_expression(
 			src_tokens,
 			ast::expression_type_kind::type_name,
 			ast::make_typename_typespec(nullptr),
-			ast::constant_value(ast::make_base_type_typespec(src_tokens, &info)),
+			ast::constant_value_storage(ast::make_base_type_typespec(src_tokens, &info)),
 			ast::make_expr_struct_name(std::move(id), type)
 		);
 	}
@@ -1737,7 +1737,7 @@ static ast::expression make_enum_type_expression(
 			src_tokens,
 			ast::expression_type_kind::type_name,
 			ast::make_typename_typespec(nullptr),
-			ast::constant_value(ast::make_enum_typespec(src_tokens, decl)),
+			ast::constant_value_storage(ast::make_enum_typespec(src_tokens, decl)),
 			ast::make_expr_enum_name(std::move(id), decl)
 		);
 	}
@@ -1760,7 +1760,7 @@ static ast::expression make_type_alias_expression(
 			src_tokens,
 			ast::expression_type_kind::type_name,
 			ast::make_typename_typespec(nullptr),
-			ast::constant_value(type),
+			ast::constant_value_storage(type),
 			ast::make_expr_type_alias_name(std::move(id), type_alias)
 		);
 	}
@@ -2157,7 +2157,7 @@ ast::expression parse_context::make_identifier_expression(ast::identifier id)
 				src_tokens,
 				ast::expression_type_kind::type_name,
 				ast::make_typename_typespec(nullptr),
-				ast::constant_value(ast::make_void_typespec(id.tokens.begin)),
+				ast::constant_value_storage(ast::make_void_typespec(id.tokens.begin)),
 				ast::make_expr_struct_name(std::move(id), nullptr)
 			);
 		}
@@ -2175,7 +2175,7 @@ ast::expression parse_context::make_identifier_expression(ast::identifier id)
 						src_tokens,
 						ast::expression_type_kind::function_name,
 						get_function_type(func_decl->body),
-						ast::constant_value(&func_decl->body),
+						ast::constant_value_storage(&func_decl->body),
 						ast::make_expr_function_name(std::move(id), func_decl)
 					);
 				}
@@ -2327,8 +2327,8 @@ static ast::expression get_literal_expr(
 				ast::expression_type_kind::integer_literal,
 				ast::make_base_type_typespec(src_tokens, default_type_info),
 				ast::is_signed_integer_kind(default_type_info->kind)
-					? ast::constant_value(static_cast<int64_t>(value))
-					: ast::constant_value(value),
+					? ast::constant_value_storage(static_cast<int64_t>(value))
+					: ast::constant_value_storage(value),
 				ast::make_expr_integer_literal(kind)
 			);
 		}
@@ -2339,8 +2339,8 @@ static ast::expression get_literal_expr(
 				ast::expression_type_kind::integer_literal,
 				ast::make_base_type_typespec(src_tokens, wide_default_type_info),
 				ast::is_signed_integer_kind(wide_default_type_info->kind)
-					? ast::constant_value(static_cast<int64_t>(value))
-					: ast::constant_value(value),
+					? ast::constant_value_storage(static_cast<int64_t>(value))
+					: ast::constant_value_storage(value),
 				ast::make_expr_integer_literal(kind)
 			);
 		}
@@ -2351,7 +2351,7 @@ static ast::expression get_literal_expr(
 				src_tokens,
 				ast::expression_type_kind::integer_literal,
 				ast::make_base_type_typespec(src_tokens, info),
-				ast::constant_value(value),
+				ast::constant_value_storage(value),
 				ast::make_expr_integer_literal(kind)
 			);
 		}
@@ -2516,8 +2516,8 @@ static ast::expression get_literal_expr(
 			ast::expression_type_kind::rvalue,
 			ast::make_base_type_typespec(src_tokens, info),
 			ast::is_signed_integer_kind(info->kind)
-				? ast::constant_value(static_cast<int64_t>(value))
-				: ast::constant_value(value),
+				? ast::constant_value_storage(static_cast<int64_t>(value))
+				: ast::constant_value_storage(value),
 			ast::make_expr_typed_literal(src_tokens.pivot)
 		);
 	}
@@ -2605,7 +2605,7 @@ ast::expression parse_context::make_literal(lex::token_pos literal) const
 				src_tokens,
 				ast::expression_type_kind::rvalue,
 				ast::make_base_type_typespec(src_tokens, info),
-				ast::constant_value(value),
+				ast::constant_value_storage(value),
 				ast::make_expr_typed_literal(literal)
 			);
 		}
@@ -2640,7 +2640,7 @@ ast::expression parse_context::make_literal(lex::token_pos literal) const
 				src_tokens,
 				ast::expression_type_kind::rvalue,
 				ast::make_base_type_typespec(src_tokens, info),
-				ast::constant_value(value),
+				ast::constant_value_storage(value),
 				ast::make_expr_typed_literal(literal)
 			);
 		}
@@ -2685,7 +2685,7 @@ ast::expression parse_context::make_literal(lex::token_pos literal) const
 			src_tokens,
 			ast::expression_type_kind::rvalue,
 			ast::make_base_type_typespec(src_tokens, this->get_builtin_type_info(ast::type_info::char_)),
-			ast::constant_value(value),
+			ast::constant_value_storage(value),
 			ast::make_expr_typed_literal(literal)
 		);
 	}
@@ -2694,7 +2694,7 @@ ast::expression parse_context::make_literal(lex::token_pos literal) const
 			src_tokens,
 			ast::expression_type_kind::rvalue,
 			ast::make_base_type_typespec(src_tokens, this->get_builtin_type_info(ast::type_info::bool_)),
-			ast::constant_value(true),
+			ast::constant_value_storage(true),
 			ast::make_expr_typed_literal(literal)
 		);
 	case lex::token::kw_false:
@@ -2702,7 +2702,7 @@ ast::expression parse_context::make_literal(lex::token_pos literal) const
 			src_tokens,
 			ast::expression_type_kind::rvalue,
 			ast::make_base_type_typespec(src_tokens, this->get_builtin_type_info(ast::type_info::bool_)),
-			ast::constant_value(false),
+			ast::constant_value_storage(false),
 			ast::make_expr_typed_literal(literal)
 		);
 	case lex::token::kw_null:
@@ -2710,7 +2710,7 @@ ast::expression parse_context::make_literal(lex::token_pos literal) const
 			src_tokens,
 			ast::expression_type_kind::null_literal,
 			ast::make_base_type_typespec(src_tokens, this->get_builtin_type_info(ast::type_info::null_t_)),
-			ast::constant_value::get_null(),
+			ast::constant_value_storage::get_null(),
 			ast::make_expr_null_literal()
 		);
 	case lex::token::placeholder_literal:
@@ -2718,7 +2718,7 @@ ast::expression parse_context::make_literal(lex::token_pos literal) const
 			src_tokens,
 			ast::expression_type_kind::placeholder_literal,
 			ast::make_void_typespec(src_tokens.pivot),
-			ast::constant_value(),
+			ast::constant_value_storage(),
 			ast::make_expr_placeholder_literal()
 		);
 	default:
@@ -2774,7 +2774,7 @@ ast::expression parse_context::make_string_literal(lex::token_pos const begin, l
 		{ begin, begin, end },
 		ast::expression_type_kind::rvalue,
 		ast::make_base_type_typespec({ begin, begin, end }, this->get_builtin_type_info(ast::type_info::str_)),
-		ast::constant_value(result),
+		ast::constant_value_storage(result),
 		ast::make_expr_typed_literal(lex::token_range{ begin, end })
 	);
 }
@@ -2820,7 +2820,7 @@ ast::expression parse_context::make_tuple(lex::src_tokens const &src_tokens, ast
 			src_tokens,
 			ast::expression_type_kind::type_name,
 			ast::typespec(),
-			ast::constant_value(ast::make_tuple_typespec(src_tokens, std::move(types))),
+			ast::constant_value_storage(ast::make_tuple_typespec(src_tokens, std::move(types))),
 			ast::make_expr_tuple(std::move(elems))
 		);
 	}
@@ -2847,7 +2847,7 @@ ast::expression parse_context::make_unreachable(lex::token_pos t)
 		src_tokens,
 		ast::expression_type_kind::rvalue,
 		ast::make_base_type_typespec(src_tokens, this->get_builtin_type_info(ast::type_info::str_)),
-		ast::constant_value(std::move(message)),
+		ast::constant_value_storage(std::move(message)),
 		ast::make_expr_typed_literal(lex::token_range{ t, t + 1 })
 	));
 	auto panic_fn_call_expr = ast::make_dynamic_expression(
@@ -3692,7 +3692,7 @@ static ast::expression make_expr_function_call_from_body(
 	lex::src_tokens const &src_tokens,
 	ast::function_body *body,
 	ast::arena_vector<ast::expression> args,
-	ast::constant_value value,
+	ast::constant_value_storage value,
 	parse_context &context,
 	ast::resolve_order resolve_order = ast::resolve_order::regular
 )
@@ -4921,8 +4921,8 @@ ast::expression parse_context::make_universal_function_call_expression(
 		)
 		{
 			auto const &array_t = args.front().get_expr_type().remove_any_mut().get<ast::ts_array>();
-			ast::constant_value size;
-			size.emplace<ast::constant_value::uint>(array_t.size);
+			ast::constant_value_storage size;
+			size.emplace<ast::constant_value_storage::uint>(array_t.size);
 			return make_expr_function_call_from_body(src_tokens, best_body, std::move(args), std::move(size), *this);
 		}
 		else
@@ -5206,8 +5206,8 @@ ast::expression parse_context::make_cast_expression(
 			inner_expr.src_tokens,
 			ast::expression_type_kind::rvalue, type,
 			value.value.is<int64_t>()
-				? ast::constant_value::get_enum(decl, value.value.get<int64_t>())
-				: ast::constant_value::get_enum(decl, value.value.get<uint64_t>()),
+				? ast::constant_value_storage::get_enum(decl, value.value.get<int64_t>())
+				: ast::constant_value_storage::get_enum(decl, value.value.get<uint64_t>()),
 			ast::make_expr_enum_literal(id)
 		);
 		return expr;
@@ -5603,8 +5603,8 @@ ast::expression parse_context::make_member_access_expression(
 			{
 				bz_assert(result_it->value.not_null());
 				auto value = result_it->value.is<int64_t>()
-					? ast::constant_value::get_enum(decl, result_it->value.get<int64_t>())
-					: ast::constant_value::get_enum(decl, result_it->value.get<uint64_t>());
+					? ast::constant_value_storage::get_enum(decl, result_it->value.get<int64_t>())
+					: ast::constant_value_storage::get_enum(decl, result_it->value.get<uint64_t>());
 				return ast::make_constant_expression(
 					src_tokens,
 					ast::expression_type_kind::rvalue, type,
@@ -5867,7 +5867,7 @@ ast::expression parse_context::make_generic_type_instantiation_expression(
 	return ast::make_constant_expression(
 		src_tokens,
 		ast::expression_type_kind::type_name, ast::make_typename_typespec(nullptr),
-		ast::constant_value(ast::make_base_type_typespec(src_tokens, info)),
+		ast::constant_value_storage(ast::make_base_type_typespec(src_tokens, info)),
 		ast::make_expr_generic_type_instantiation(info)
 	);
 }
@@ -5998,24 +5998,24 @@ static ast::expression make_builtin_default_construction(
 			case ast::type_info::int16_:
 			case ast::type_info::int32_:
 			case ast::type_info::int64_:
-				return ast::constant_value(int64_t());
+				return ast::constant_value_storage(int64_t());
 			case ast::type_info::uint8_:
 			case ast::type_info::uint16_:
 			case ast::type_info::uint32_:
 			case ast::type_info::uint64_:
-				return ast::constant_value(uint64_t());
+				return ast::constant_value_storage(uint64_t());
 			case ast::type_info::float32_:
-				return ast::constant_value(float32_t());
+				return ast::constant_value_storage(float32_t());
 			case ast::type_info::float64_:
-				return ast::constant_value(float64_t());
+				return ast::constant_value_storage(float64_t());
 			case ast::type_info::char_:
-				return ast::constant_value(bz::u8char());
+				return ast::constant_value_storage(bz::u8char());
 			case ast::type_info::str_:
-				return ast::constant_value(bz::u8string());
+				return ast::constant_value_storage(bz::u8string());
 			case ast::type_info::bool_:
-				return ast::constant_value(bool());
+				return ast::constant_value_storage(bool());
 			case ast::type_info::null_t_:
-				return ast::constant_value::get_null();
+				return ast::constant_value_storage::get_null();
 			default:
 				bz_unreachable;
 			}
@@ -8367,7 +8367,7 @@ ast::identifier parse_context::make_qualified_identifier(lex::token_pos id)
 	return result;
 }
 
-ast::constant_value parse_context::execute_expression(ast::expression &expr)
+ast::constant_value_storage parse_context::execute_expression(ast::expression &expr)
 {
 	auto &codegen_context = this->global_ctx.get_codegen_context();
 
@@ -8390,7 +8390,7 @@ ast::constant_value parse_context::execute_expression(ast::expression &expr)
 	return result;
 }
 
-ast::constant_value parse_context::execute_expression_without_error(ast::expression &expr)
+ast::constant_value_storage parse_context::execute_expression_without_error(ast::expression &expr)
 {
 	auto &codegen_context = this->global_ctx.get_codegen_context();
 	auto const func = comptime::generate_code_for_expression(expr, codegen_context);

--- a/src/ctx/parse_context.cpp
+++ b/src/ctx/parse_context.cpp
@@ -175,47 +175,47 @@ ast::type_prototype_set_t &parse_context::get_type_prototype_set(void)
 	return *this->global_ctx.type_prototype_set;
 }
 
-ast::constant_value parse_context::add_constant_string(bz::u8string str)
+ast::constant_value parse_context::add_constant_string(bz::u8string_view str) const
 {
-	return this->global_ctx.add_constant_string(std::move(str));
+	return this->global_ctx.add_constant_string(str);
 }
 
-ast::constant_value parse_context::add_constant_array(ast::arena_vector<ast::constant_value_storage> elems)
+ast::constant_value parse_context::add_constant_array(ast::arena_vector<ast::constant_value> elems) const
 {
 	return this->global_ctx.add_constant_array(std::move(elems));
 }
 
-ast::constant_value parse_context::add_constant_tuple(ast::arena_vector<ast::constant_value_storage> elems)
+ast::constant_value parse_context::add_constant_tuple(ast::arena_vector<ast::constant_value> elems) const
 {
 	return this->global_ctx.add_constant_tuple(std::move(elems));
 }
 
-ast::constant_value parse_context::add_constant_aggregate(ast::arena_vector<ast::constant_value_storage> elems)
+ast::constant_value parse_context::add_constant_aggregate(ast::arena_vector<ast::constant_value> elems) const
 {
 	return this->global_ctx.add_constant_aggregate(std::move(elems));
 }
 
-ast::constant_value parse_context::add_constant_sint_array(ast::arena_vector<int64_t> elems)
+ast::constant_value parse_context::add_constant_sint_array(ast::arena_vector<int64_t> elems) const
 {
 	return this->global_ctx.add_constant_sint_array(std::move(elems));
 }
 
-ast::constant_value parse_context::add_constant_uint_array(ast::arena_vector<uint64_t> elems)
+ast::constant_value parse_context::add_constant_uint_array(ast::arena_vector<uint64_t> elems) const
 {
 	return this->global_ctx.add_constant_uint_array(std::move(elems));
 }
 
-ast::constant_value parse_context::add_constant_float32_array(ast::arena_vector<float32_t> elems)
+ast::constant_value parse_context::add_constant_float32_array(ast::arena_vector<float32_t> elems) const
 {
 	return this->global_ctx.add_constant_float32_array(std::move(elems));
 }
 
-ast::constant_value parse_context::add_constant_float64_array(ast::arena_vector<float64_t> elems)
+ast::constant_value parse_context::add_constant_float64_array(ast::arena_vector<float64_t> elems) const
 {
 	return this->global_ctx.add_constant_float64_array(std::move(elems));
 }
 
-ast::constant_value parse_context::add_constant_type(ast::typespec type)
+ast::constant_value parse_context::add_constant_type(ast::typespec type) const
 {
 	return this->global_ctx.add_constant_type(std::move(type));
 }
@@ -1564,6 +1564,7 @@ static ast::expression make_variable_expression(
 	ast::typespec result_type = var_decl->get_type();
 	if (result_type.is_empty())
 	{
+		bz::log("{}\n", context.global_ctx.get_location_string(var_decl->src_tokens.pivot));
 		bz_assert(context.has_errors());
 		return ast::make_error_expression(src_tokens, std::move(result_expr));
 	}
@@ -1599,7 +1600,7 @@ static ast::expression make_variable_expression(
 		return ast::make_constant_expression(
 			src_tokens,
 			ast::expression_type_kind::type_name, ast::make_typename_typespec(nullptr),
-			ast::constant_value_storage(init_expr.get_typename()),
+			init_expr.get_constant_value(),
 			std::move(result_expr)
 		);
 	}
@@ -1663,7 +1664,7 @@ static ast::expression make_function_name_expression(
 		return ast::make_constant_expression(
 			src_tokens,
 			ast::expression_type_kind::function_name, ast::typespec(),
-			ast::constant_value_storage(),
+			ast::constant_value(),
 			ast::make_expr_function_name(std::move(id), func_decl)
 		);
 	}
@@ -1672,7 +1673,7 @@ static ast::expression make_function_name_expression(
 		return ast::make_constant_expression(
 			src_tokens,
 			ast::expression_type_kind::function_name, get_function_type(func_decl->body),
-			ast::constant_value_storage(&func_decl->body),
+			ast::constant_value(&func_decl->body),
 			ast::make_expr_function_name(std::move(id), func_decl)
 		);
 	}
@@ -1690,7 +1691,7 @@ static ast::expression make_function_name_expression(
 		return ast::make_constant_expression(
 			src_tokens,
 			ast::expression_type_kind::function_alias_name, get_function_type(decl->body),
-			ast::constant_value_storage(&decl->body),
+			ast::constant_value(&decl->body),
 			ast::make_expr_function_alias_name(std::move(id), alias_decl)
 		);
 	}
@@ -1699,7 +1700,7 @@ static ast::expression make_function_name_expression(
 		return ast::make_constant_expression(
 			src_tokens,
 			ast::expression_type_kind::function_alias_name, ast::typespec(),
-			ast::constant_value_storage(),
+			ast::constant_value(),
 			ast::make_expr_function_alias_name(std::move(id), alias_decl)
 		);
 	}
@@ -1734,7 +1735,7 @@ static ast::expression make_function_name_expression(
 		return ast::make_constant_expression(
 			src_tokens,
 			ast::expression_type_kind::function_overload_set, ast::typespec(),
-			ast::constant_value_storage(),
+			ast::constant_value(),
 			ast::make_expr_function_overload_set(std::move(id), std::move(set))
 		);
 	}
@@ -1760,7 +1761,7 @@ static ast::expression make_type_expression(
 			src_tokens,
 			ast::expression_type_kind::type_name,
 			ast::make_typename_typespec(nullptr),
-			ast::constant_value_storage(ast::make_base_type_typespec(src_tokens, &info)),
+			context.add_constant_type(ast::make_base_type_typespec(src_tokens, &info)),
 			ast::make_expr_struct_name(std::move(id), type)
 		);
 	}
@@ -1773,7 +1774,8 @@ static ast::expression make_type_expression(
 static ast::expression make_enum_type_expression(
 	lex::src_tokens const &src_tokens,
 	ast::identifier id,
-	ast::decl_enum *decl
+	ast::decl_enum *decl,
+	parse_context &context
 )
 {
 	if (decl->state != ast::resolve_state::error)
@@ -1782,7 +1784,7 @@ static ast::expression make_enum_type_expression(
 			src_tokens,
 			ast::expression_type_kind::type_name,
 			ast::make_typename_typespec(nullptr),
-			ast::constant_value_storage(ast::make_enum_typespec(src_tokens, decl)),
+			context.add_constant_type(ast::make_enum_typespec(src_tokens, decl)),
 			ast::make_expr_enum_name(std::move(id), decl)
 		);
 	}
@@ -1795,7 +1797,8 @@ static ast::expression make_enum_type_expression(
 static ast::expression make_type_alias_expression(
 	lex::src_tokens const &src_tokens,
 	ast::identifier id,
-	ast::decl_type_alias *type_alias
+	ast::decl_type_alias *type_alias,
+	parse_context &context
 )
 {
 	auto const type = type_alias->get_type();
@@ -1805,7 +1808,7 @@ static ast::expression make_type_alias_expression(
 			src_tokens,
 			ast::expression_type_kind::type_name,
 			ast::make_typename_typespec(nullptr),
-			ast::constant_value_storage(type),
+			context.add_constant_type(type),
 			ast::make_expr_type_alias_name(std::move(id), type_alias)
 		);
 	}
@@ -1951,12 +1954,12 @@ static ast::expression expression_from_symbol(
 			resolve::resolve_type_alias(*alias_decl, context);
 			context.pop_resolve_queue();
 		}
-		return make_type_alias_expression(src_tokens, std::move(id), symbol.get<ast::decl_type_alias *>());
+		return make_type_alias_expression(src_tokens, std::move(id), symbol.get<ast::decl_type_alias *>(), context);
 	}
 	case symbol_t::index_of<ast::decl_struct *>:
 		return make_type_expression(src_tokens, std::move(id), symbol.get<ast::decl_struct *>(), context);
 	case symbol_t::index_of<ast::decl_enum *>:
-		return make_enum_type_expression(src_tokens, std::move(id), symbol.get<ast::decl_enum *>());
+		return make_enum_type_expression(src_tokens, std::move(id), symbol.get<ast::decl_enum *>(), context);
 	default:
 		bz_unreachable;
 	}
@@ -2154,6 +2157,35 @@ static id_search_result_t find_id_in_scope(ast::enclosing_scope_t scope, ast::id
 	return {};
 }
 
+ast::expression parse_context::auto_type_as_expression(lex::src_tokens const &src_tokens) const
+{
+	return ast::make_constant_expression(
+		src_tokens,
+		ast::expression_type_kind::type_name,
+		ast::make_typename_typespec(nullptr),
+		ast::constant_value(this->global_ctx.cached_auto_type),
+		ast::expr_t()
+	);
+}
+
+ast::expression parse_context::type_as_expression(lex::src_tokens const &src_tokens, ast::typespec type) const
+{
+	if (type.is<ast::ts_auto>() && type.src_tokens.pivot == nullptr)
+	{
+		return this->auto_type_as_expression(src_tokens);
+	}
+	else
+	{
+		return ast::make_constant_expression(
+			src_tokens,
+			ast::expression_type_kind::type_name,
+			ast::make_typename_typespec(nullptr),
+			this->add_constant_type(std::move(type)),
+			ast::expr_t()
+		);
+	}
+}
+
 ast::expression parse_context::make_identifier_expression(ast::identifier id)
 {
 	// ==== local decls ====
@@ -2202,7 +2234,7 @@ ast::expression parse_context::make_identifier_expression(ast::identifier id)
 				src_tokens,
 				ast::expression_type_kind::type_name,
 				ast::make_typename_typespec(nullptr),
-				ast::constant_value_storage(ast::make_void_typespec(id.tokens.begin)),
+				this->add_constant_type(ast::make_void_typespec(id.tokens.begin)),
 				ast::make_expr_struct_name(std::move(id), nullptr)
 			);
 		}
@@ -2220,7 +2252,7 @@ ast::expression parse_context::make_identifier_expression(ast::identifier id)
 						src_tokens,
 						ast::expression_type_kind::function_name,
 						get_function_type(func_decl->body),
-						ast::constant_value_storage(&func_decl->body),
+						ast::constant_value(&func_decl->body),
 						ast::make_expr_function_name(std::move(id), func_decl)
 					);
 				}
@@ -2372,8 +2404,8 @@ static ast::expression get_literal_expr(
 				ast::expression_type_kind::integer_literal,
 				ast::make_base_type_typespec(src_tokens, default_type_info),
 				ast::is_signed_integer_kind(default_type_info->kind)
-					? ast::constant_value_storage(static_cast<int64_t>(value))
-					: ast::constant_value_storage(value),
+					? ast::constant_value(static_cast<int64_t>(value))
+					: ast::constant_value(value),
 				ast::make_expr_integer_literal(kind)
 			);
 		}
@@ -2384,8 +2416,8 @@ static ast::expression get_literal_expr(
 				ast::expression_type_kind::integer_literal,
 				ast::make_base_type_typespec(src_tokens, wide_default_type_info),
 				ast::is_signed_integer_kind(wide_default_type_info->kind)
-					? ast::constant_value_storage(static_cast<int64_t>(value))
-					: ast::constant_value_storage(value),
+					? ast::constant_value(static_cast<int64_t>(value))
+					: ast::constant_value(value),
 				ast::make_expr_integer_literal(kind)
 			);
 		}
@@ -2396,7 +2428,7 @@ static ast::expression get_literal_expr(
 				src_tokens,
 				ast::expression_type_kind::integer_literal,
 				ast::make_base_type_typespec(src_tokens, info),
-				ast::constant_value_storage(value),
+				ast::constant_value(value),
 				ast::make_expr_integer_literal(kind)
 			);
 		}
@@ -2561,8 +2593,8 @@ static ast::expression get_literal_expr(
 			ast::expression_type_kind::rvalue,
 			ast::make_base_type_typespec(src_tokens, info),
 			ast::is_signed_integer_kind(info->kind)
-				? ast::constant_value_storage(static_cast<int64_t>(value))
-				: ast::constant_value_storage(value),
+				? ast::constant_value(static_cast<int64_t>(value))
+				: ast::constant_value(value),
 			ast::make_expr_typed_literal(src_tokens.pivot)
 		);
 	}
@@ -2644,13 +2676,13 @@ ast::expression parse_context::make_literal(lex::token_pos literal) const
 				);
 			}
 
-			auto const value = num.has_value() ? num.get() : 0.0f;
+			float32_t const value = num.has_value() ? num.get() : 0.0f;
 			auto const info = this->get_builtin_type_info(ast::type_info::float32_);
 			return ast::make_constant_expression(
 				src_tokens,
 				ast::expression_type_kind::rvalue,
 				ast::make_base_type_typespec(src_tokens, info),
-				ast::constant_value_storage(value),
+				ast::constant_value(value),
 				ast::make_expr_typed_literal(literal)
 			);
 		}
@@ -2685,7 +2717,7 @@ ast::expression parse_context::make_literal(lex::token_pos literal) const
 				src_tokens,
 				ast::expression_type_kind::rvalue,
 				ast::make_base_type_typespec(src_tokens, info),
-				ast::constant_value_storage(value),
+				ast::constant_value(value),
 				ast::make_expr_typed_literal(literal)
 			);
 		}
@@ -2730,7 +2762,7 @@ ast::expression parse_context::make_literal(lex::token_pos literal) const
 			src_tokens,
 			ast::expression_type_kind::rvalue,
 			ast::make_base_type_typespec(src_tokens, this->get_builtin_type_info(ast::type_info::char_)),
-			ast::constant_value_storage(value),
+			ast::constant_value(value),
 			ast::make_expr_typed_literal(literal)
 		);
 	}
@@ -2739,7 +2771,7 @@ ast::expression parse_context::make_literal(lex::token_pos literal) const
 			src_tokens,
 			ast::expression_type_kind::rvalue,
 			ast::make_base_type_typespec(src_tokens, this->get_builtin_type_info(ast::type_info::bool_)),
-			ast::constant_value_storage(true),
+			ast::constant_value(true),
 			ast::make_expr_typed_literal(literal)
 		);
 	case lex::token::kw_false:
@@ -2747,7 +2779,7 @@ ast::expression parse_context::make_literal(lex::token_pos literal) const
 			src_tokens,
 			ast::expression_type_kind::rvalue,
 			ast::make_base_type_typespec(src_tokens, this->get_builtin_type_info(ast::type_info::bool_)),
-			ast::constant_value_storage(false),
+			ast::constant_value(false),
 			ast::make_expr_typed_literal(literal)
 		);
 	case lex::token::kw_null:
@@ -2755,7 +2787,7 @@ ast::expression parse_context::make_literal(lex::token_pos literal) const
 			src_tokens,
 			ast::expression_type_kind::null_literal,
 			ast::make_base_type_typespec(src_tokens, this->get_builtin_type_info(ast::type_info::null_t_)),
-			ast::constant_value_storage::get_null(),
+			ast::constant_value::get_null(),
 			ast::make_expr_null_literal()
 		);
 	case lex::token::placeholder_literal:
@@ -2763,7 +2795,7 @@ ast::expression parse_context::make_literal(lex::token_pos literal) const
 			src_tokens,
 			ast::expression_type_kind::placeholder_literal,
 			ast::make_void_typespec(src_tokens.pivot),
-			ast::constant_value_storage(),
+			ast::constant_value(),
 			ast::make_expr_placeholder_literal()
 		);
 	default:
@@ -2819,7 +2851,7 @@ ast::expression parse_context::make_string_literal(lex::token_pos const begin, l
 		{ begin, begin, end },
 		ast::expression_type_kind::rvalue,
 		ast::make_base_type_typespec({ begin, begin, end }, this->get_builtin_type_info(ast::type_info::str_)),
-		ast::constant_value_storage(result),
+		this->add_constant_string(std::move(result)),
 		ast::make_expr_typed_literal(lex::token_range{ begin, end })
 	);
 }
@@ -2865,7 +2897,7 @@ ast::expression parse_context::make_tuple(lex::src_tokens const &src_tokens, ast
 			src_tokens,
 			ast::expression_type_kind::type_name,
 			ast::typespec(),
-			ast::constant_value_storage(ast::make_tuple_typespec(src_tokens, std::move(types))),
+			this->add_constant_type(ast::make_tuple_typespec(src_tokens, std::move(types))),
 			ast::make_expr_tuple(std::move(elems))
 		);
 	}
@@ -2892,7 +2924,7 @@ ast::expression parse_context::make_unreachable(lex::token_pos t)
 		src_tokens,
 		ast::expression_type_kind::rvalue,
 		ast::make_base_type_typespec(src_tokens, this->get_builtin_type_info(ast::type_info::str_)),
-		ast::constant_value_storage(std::move(message)),
+		this->add_constant_string(std::move(message)),
 		ast::make_expr_typed_literal(lex::token_range{ t, t + 1 })
 	));
 	auto panic_fn_call_expr = ast::make_dynamic_expression(
@@ -3575,7 +3607,7 @@ static ast::expression make_expr_function_call_from_body(
 	{
 		bz_assert(args.size() == 2);
 		bz_assert(args[0].is_typename());
-		auto const &type = args[0].get_typename();
+		auto const type = args[0].get_typename();
 		context.add_self_destruction(args[1]);
 		return make_array_value_init_expression(src_tokens, type, std::move(args[1]), context);
 	}
@@ -3583,10 +3615,10 @@ static ast::expression make_expr_function_call_from_body(
 	{
 		bz_assert(args.size() == 2);
 		bz_assert(args[0].is_typename());
-		auto &type = args[0].get_typename();
+		auto const type = args[0].get_typename();
 		bz_assert(body->return_type == type);
 		context.add_self_destruction(args[1]);
-		return context.make_bit_cast_expression(src_tokens, std::move(args[1]), std::move(type));
+		return context.make_bit_cast_expression(src_tokens, std::move(args[1]), type);
 	}
 	else if (
 		body->is_intrinsic()
@@ -3737,7 +3769,7 @@ static ast::expression make_expr_function_call_from_body(
 	lex::src_tokens const &src_tokens,
 	ast::function_body *body,
 	ast::arena_vector<ast::expression> args,
-	ast::constant_value_storage value,
+	ast::constant_value value,
 	parse_context &context,
 	ast::resolve_order resolve_order = ast::resolve_order::regular
 )
@@ -4189,7 +4221,7 @@ ast::expression parse_context::make_binary_operator_expression(
 			return ast::make_error_expression(src_tokens, ast::make_expr_binary_op(op_kind, std::move(lhs), std::move(rhs)));
 		}
 
-		return this->make_cast_expression(src_tokens, std::move(lhs), std::move(rhs.get_typename()));
+		return this->make_cast_expression(src_tokens, std::move(lhs), rhs.get_typename());
 	}
 
 	if (is_binary_type_op(op_kind) && lhs.is_typename() && rhs.is_typename())
@@ -4495,7 +4527,7 @@ static ast::expression make_constructor_call_expression(
 	parse_context &context
 )
 {
-	auto const called_type = called.get_typename().as_typespec_view();
+	auto const called_type = called.get_typename();
 	if (called_type.is<ast::ts_base_type>())
 	{
 		return make_base_type_constructor_call_expression(src_tokens, called_type, std::move(args), context);
@@ -4966,7 +4998,7 @@ ast::expression parse_context::make_universal_function_call_expression(
 		)
 		{
 			auto const &array_t = args.front().get_expr_type().remove_any_mut().get<ast::ts_array>();
-			ast::constant_value_storage size;
+			ast::constant_value size;
 			size.emplace<ast::constant_value_kind::uint>(array_t.size);
 			return make_expr_function_call_from_body(src_tokens, best_body, std::move(args), std::move(size), *this);
 		}
@@ -5002,7 +5034,7 @@ ast::expression parse_context::make_subscript_operator_expression(
 
 	if (called.is_typename())
 	{
-		ast::typespec_view const type = called.get_typename();
+		auto const type = called.get_typename();
 		auto const bare_type = type.remove_any_mut();
 		if (!bare_type.is<ast::ts_base_type>())
 		{
@@ -5251,8 +5283,8 @@ ast::expression parse_context::make_cast_expression(
 			inner_expr.src_tokens,
 			ast::expression_type_kind::rvalue, type,
 			value.value.is<int64_t>()
-				? ast::constant_value_storage::get_enum(decl, value.value.get<int64_t>())
-				: ast::constant_value_storage::get_enum(decl, value.value.get<uint64_t>()),
+				? ast::constant_value::get_enum(decl, value.value.get<int64_t>())
+				: ast::constant_value::get_enum(decl, value.value.get<uint64_t>()),
 			ast::make_expr_enum_literal(id)
 		);
 		return expr;
@@ -5648,8 +5680,8 @@ ast::expression parse_context::make_member_access_expression(
 			{
 				bz_assert(result_it->value.not_null());
 				auto value = result_it->value.is<int64_t>()
-					? ast::constant_value_storage::get_enum(decl, result_it->value.get<int64_t>())
-					: ast::constant_value_storage::get_enum(decl, result_it->value.get<uint64_t>());
+					? ast::constant_value::get_enum(decl, result_it->value.get<int64_t>())
+					: ast::constant_value::get_enum(decl, result_it->value.get<uint64_t>());
 				return ast::make_constant_expression(
 					src_tokens,
 					ast::expression_type_kind::rvalue, type,
@@ -5912,7 +5944,7 @@ ast::expression parse_context::make_generic_type_instantiation_expression(
 	return ast::make_constant_expression(
 		src_tokens,
 		ast::expression_type_kind::type_name, ast::make_typename_typespec(nullptr),
-		ast::constant_value_storage(ast::make_base_type_typespec(src_tokens, info)),
+		this->add_constant_type(ast::make_base_type_typespec(src_tokens, info)),
 		ast::make_expr_generic_type_instantiation(info)
 	);
 }
@@ -6043,24 +6075,24 @@ static ast::expression make_builtin_default_construction(
 			case ast::type_info::int16_:
 			case ast::type_info::int32_:
 			case ast::type_info::int64_:
-				return ast::constant_value_storage(int64_t());
+				return ast::constant_value(int64_t());
 			case ast::type_info::uint8_:
 			case ast::type_info::uint16_:
 			case ast::type_info::uint32_:
 			case ast::type_info::uint64_:
-				return ast::constant_value_storage(uint64_t());
+				return ast::constant_value(uint64_t());
 			case ast::type_info::float32_:
-				return ast::constant_value_storage(float32_t());
+				return ast::constant_value(float32_t());
 			case ast::type_info::float64_:
-				return ast::constant_value_storage(float64_t());
+				return ast::constant_value(float64_t());
 			case ast::type_info::char_:
-				return ast::constant_value_storage(bz::u8char());
+				return ast::constant_value(bz::u8char());
 			case ast::type_info::str_:
-				return ast::constant_value_storage(bz::u8string());
+				return ast::constant_value(bz::u8string_view());
 			case ast::type_info::bool_:
-				return ast::constant_value_storage(bool());
+				return ast::constant_value(bool());
 			case ast::type_info::null_t_:
-				return ast::constant_value_storage::get_null();
+				return ast::constant_value::get_null();
 			default:
 				bz_unreachable;
 			}
@@ -8412,7 +8444,7 @@ ast::identifier parse_context::make_qualified_identifier(lex::token_pos id)
 	return result;
 }
 
-ast::constant_value_storage parse_context::execute_expression(ast::expression &expr)
+ast::constant_value parse_context::execute_expression(ast::expression &expr)
 {
 	auto &codegen_context = this->global_ctx.get_codegen_context();
 
@@ -8435,7 +8467,7 @@ ast::constant_value_storage parse_context::execute_expression(ast::expression &e
 	return result;
 }
 
-ast::constant_value_storage parse_context::execute_expression_without_error(ast::expression &expr)
+ast::constant_value parse_context::execute_expression_without_error(ast::expression &expr)
 {
 	auto &codegen_context = this->global_ctx.get_codegen_context();
 	auto const func = comptime::generate_code_for_expression(expr, codegen_context);

--- a/src/ctx/parse_context.cpp
+++ b/src/ctx/parse_context.cpp
@@ -4922,7 +4922,7 @@ ast::expression parse_context::make_universal_function_call_expression(
 		{
 			auto const &array_t = args.front().get_expr_type().remove_any_mut().get<ast::ts_array>();
 			ast::constant_value_storage size;
-			size.emplace<ast::constant_value_storage::uint>(array_t.size);
+			size.emplace<ast::constant_value_kind::uint>(array_t.size);
 			return make_expr_function_call_from_body(src_tokens, best_body, std::move(args), std::move(size), *this);
 		}
 		else

--- a/src/ctx/parse_context.cpp
+++ b/src/ctx/parse_context.cpp
@@ -175,6 +175,51 @@ ast::type_prototype_set_t &parse_context::get_type_prototype_set(void)
 	return *this->global_ctx.type_prototype_set;
 }
 
+ast::constant_value parse_context::add_constant_string(bz::u8string str)
+{
+	return this->global_ctx.add_constant_string(std::move(str));
+}
+
+ast::constant_value parse_context::add_constant_array(ast::arena_vector<ast::constant_value_storage> elems)
+{
+	return this->global_ctx.add_constant_array(std::move(elems));
+}
+
+ast::constant_value parse_context::add_constant_tuple(ast::arena_vector<ast::constant_value_storage> elems)
+{
+	return this->global_ctx.add_constant_tuple(std::move(elems));
+}
+
+ast::constant_value parse_context::add_constant_aggregate(ast::arena_vector<ast::constant_value_storage> elems)
+{
+	return this->global_ctx.add_constant_aggregate(std::move(elems));
+}
+
+ast::constant_value parse_context::add_constant_sint_array(ast::arena_vector<int64_t> elems)
+{
+	return this->global_ctx.add_constant_sint_array(std::move(elems));
+}
+
+ast::constant_value parse_context::add_constant_uint_array(ast::arena_vector<uint64_t> elems)
+{
+	return this->global_ctx.add_constant_uint_array(std::move(elems));
+}
+
+ast::constant_value parse_context::add_constant_float32_array(ast::arena_vector<float32_t> elems)
+{
+	return this->global_ctx.add_constant_float32_array(std::move(elems));
+}
+
+ast::constant_value parse_context::add_constant_float64_array(ast::arena_vector<float64_t> elems)
+{
+	return this->global_ctx.add_constant_float64_array(std::move(elems));
+}
+
+ast::constant_value parse_context::add_constant_type(ast::typespec type)
+{
+	return this->global_ctx.add_constant_type(std::move(type));
+}
+
 [[nodiscard]] parse_context::loop_info_t parse_context::push_loop(void) noexcept
 {
 	auto const prev_in_loop = this->in_loop;

--- a/src/ctx/parse_context.h
+++ b/src/ctx/parse_context.h
@@ -492,8 +492,8 @@ struct parse_context
 
 	ast::identifier make_qualified_identifier(lex::token_pos id);
 
-	ast::constant_value execute_expression(ast::expression &expr);
-	ast::constant_value execute_expression_without_error(ast::expression &expr);
+	ast::constant_value_storage execute_expression(ast::expression &expr);
+	ast::constant_value_storage execute_expression_without_error(ast::expression &expr);
 
 	// bool is_implicitly_convertible(ast::expression const &from, ast::typespec_view to);
 	// bool is_explicitly_convertible(ast::expression const &from, ast::typespec_view to);

--- a/src/ctx/parse_context.h
+++ b/src/ctx/parse_context.h
@@ -95,15 +95,15 @@ struct parse_context
 	bz::array_view<uint32_t const> get_builtin_universal_functions(bz::u8string_view id);
 	ast::type_prototype_set_t &get_type_prototype_set(void);
 
-	ast::constant_value add_constant_string(bz::u8string str);
-	ast::constant_value add_constant_array(ast::arena_vector<ast::constant_value_storage> elems);
-	ast::constant_value add_constant_tuple(ast::arena_vector<ast::constant_value_storage> elems);
-	ast::constant_value add_constant_aggregate(ast::arena_vector<ast::constant_value_storage> elems);
-	ast::constant_value add_constant_sint_array(ast::arena_vector<int64_t> elems);
-	ast::constant_value add_constant_uint_array(ast::arena_vector<uint64_t> elems);
-	ast::constant_value add_constant_float32_array(ast::arena_vector<float32_t> elems);
-	ast::constant_value add_constant_float64_array(ast::arena_vector<float64_t> elems);
-	ast::constant_value add_constant_type(ast::typespec type);
+	ast::constant_value add_constant_string(bz::u8string_view str) const;
+	ast::constant_value add_constant_array(ast::arena_vector<ast::constant_value> elems) const;
+	ast::constant_value add_constant_tuple(ast::arena_vector<ast::constant_value> elems) const;
+	ast::constant_value add_constant_aggregate(ast::arena_vector<ast::constant_value> elems) const;
+	ast::constant_value add_constant_sint_array(ast::arena_vector<int64_t> elems) const;
+	ast::constant_value add_constant_uint_array(ast::arena_vector<uint64_t> elems) const;
+	ast::constant_value add_constant_float32_array(ast::arena_vector<float32_t> elems) const;
+	ast::constant_value add_constant_float64_array(ast::arena_vector<float64_t> elems) const;
+	ast::constant_value add_constant_type(ast::typespec type) const;
 
 	struct loop_info_t
 	{
@@ -413,6 +413,8 @@ struct parse_context
 
 	void add_function_for_compilation(ast::function_body &func_body) const;
 
+	ast::expression auto_type_as_expression(lex::src_tokens const &src_tokens) const;
+	ast::expression type_as_expression(lex::src_tokens const &src_tokens, ast::typespec type) const;
 	ast::expression make_identifier_expression(ast::identifier id);
 	ast::expression make_literal(lex::token_pos literal) const;
 	ast::expression make_string_literal(lex::token_pos begin, lex::token_pos end) const;
@@ -502,8 +504,8 @@ struct parse_context
 
 	ast::identifier make_qualified_identifier(lex::token_pos id);
 
-	ast::constant_value_storage execute_expression(ast::expression &expr);
-	ast::constant_value_storage execute_expression_without_error(ast::expression &expr);
+	ast::constant_value execute_expression(ast::expression &expr);
+	ast::constant_value execute_expression_without_error(ast::expression &expr);
 
 	// bool is_implicitly_convertible(ast::expression const &from, ast::typespec_view to);
 	// bool is_explicitly_convertible(ast::expression const &from, ast::typespec_view to);

--- a/src/ctx/parse_context.h
+++ b/src/ctx/parse_context.h
@@ -95,6 +95,16 @@ struct parse_context
 	bz::array_view<uint32_t const> get_builtin_universal_functions(bz::u8string_view id);
 	ast::type_prototype_set_t &get_type_prototype_set(void);
 
+	ast::constant_value add_constant_string(bz::u8string str);
+	ast::constant_value add_constant_array(ast::arena_vector<ast::constant_value_storage> elems);
+	ast::constant_value add_constant_tuple(ast::arena_vector<ast::constant_value_storage> elems);
+	ast::constant_value add_constant_aggregate(ast::arena_vector<ast::constant_value_storage> elems);
+	ast::constant_value add_constant_sint_array(ast::arena_vector<int64_t> elems);
+	ast::constant_value add_constant_uint_array(ast::arena_vector<uint64_t> elems);
+	ast::constant_value add_constant_float32_array(ast::arena_vector<float32_t> elems);
+	ast::constant_value add_constant_float64_array(ast::arena_vector<float64_t> elems);
+	ast::constant_value add_constant_type(ast::typespec type);
+
 	struct loop_info_t
 	{
 		bool in_loop;

--- a/src/parse/expression_parser.cpp
+++ b/src/parse/expression_parser.cpp
@@ -215,7 +215,7 @@ ast::expression parse_compound_expression(
 		return ast::make_constant_expression(
 			{ begin, begin, stream },
 			ast::expression_type_kind::none, ast::make_void_typespec(nullptr),
-			ast::constant_value::get_void(),
+			ast::constant_value_storage::get_void(),
 			ast::make_expr_compound(decltype(statements)(), ast::expression())
 		);
 	}
@@ -574,7 +574,7 @@ static ast::expression parse_primary_expression(
 				lex::src_tokens::from_range({ dot_pos, stream }),
 				ast::expression_type_kind::enum_literal,
 				ast::typespec(),
-				ast::constant_value(),
+				ast::constant_value_storage(),
 				ast::make_expr_enum_literal(id)
 			);
 		}
@@ -680,7 +680,7 @@ static ast::expression parse_primary_expression(
 			src_tokens,
 			ast::expression_type_kind::type_name,
 			ast::make_typename_typespec(nullptr),
-			ast::constant_value(ast::make_auto_typespec(auto_pos)),
+			ast::constant_value_storage(ast::make_auto_typespec(auto_pos)),
 			ast::make_expr_typename_literal()
 		);
 	}
@@ -694,7 +694,7 @@ static ast::expression parse_primary_expression(
 			src_tokens,
 			ast::expression_type_kind::type_name,
 			ast::make_typename_typespec(nullptr),
-			ast::constant_value(ast::make_typename_typespec(typename_pos)),
+			ast::constant_value_storage(ast::make_typename_typespec(typename_pos)),
 			ast::make_expr_typename_literal()
 		);
 	}
@@ -739,7 +739,7 @@ static ast::expression parse_primary_expression(
 				src_tokens,
 				ast::expression_type_kind::type_name,
 				ast::make_typename_typespec(nullptr),
-				ast::constant_value(ast::make_void_typespec(nullptr)),
+				ast::constant_value_storage(ast::make_void_typespec(nullptr)),
 				ast::make_expr_typename_literal()
 			);
 			return ast::make_unresolved_expression(

--- a/src/parse/expression_parser.cpp
+++ b/src/parse/expression_parser.cpp
@@ -215,7 +215,7 @@ ast::expression parse_compound_expression(
 		return ast::make_constant_expression(
 			{ begin, begin, stream },
 			ast::expression_type_kind::none, ast::make_void_typespec(nullptr),
-			ast::constant_value_storage::get_void(),
+			ast::constant_value::get_void(),
 			ast::make_expr_compound(decltype(statements)(), ast::expression())
 		);
 	}
@@ -574,7 +574,7 @@ static ast::expression parse_primary_expression(
 				lex::src_tokens::from_range({ dot_pos, stream }),
 				ast::expression_type_kind::enum_literal,
 				ast::typespec(),
-				ast::constant_value_storage(),
+				ast::constant_value(),
 				ast::make_expr_enum_literal(id)
 			);
 		}
@@ -680,7 +680,7 @@ static ast::expression parse_primary_expression(
 			src_tokens,
 			ast::expression_type_kind::type_name,
 			ast::make_typename_typespec(nullptr),
-			ast::constant_value_storage(ast::make_auto_typespec(auto_pos)),
+			context.add_constant_type(ast::make_auto_typespec(auto_pos)),
 			ast::make_expr_typename_literal()
 		);
 	}
@@ -694,7 +694,7 @@ static ast::expression parse_primary_expression(
 			src_tokens,
 			ast::expression_type_kind::type_name,
 			ast::make_typename_typespec(nullptr),
-			ast::constant_value_storage(ast::make_typename_typespec(typename_pos)),
+			context.add_constant_type(ast::make_typename_typespec(typename_pos)),
 			ast::make_expr_typename_literal()
 		);
 	}
@@ -739,7 +739,7 @@ static ast::expression parse_primary_expression(
 				src_tokens,
 				ast::expression_type_kind::type_name,
 				ast::make_typename_typespec(nullptr),
-				ast::constant_value_storage(ast::make_void_typespec(nullptr)),
+				context.add_constant_type(ast::make_void_typespec(nullptr)),
 				ast::make_expr_typename_literal()
 			);
 			return ast::make_unresolved_expression(

--- a/src/parse/statement_parser.cpp
+++ b/src/parse/statement_parser.cpp
@@ -115,7 +115,7 @@ static ast::decl_variable parse_decl_variable_id_and_type(
 				prototype,
 				ast::var_id_and_type(
 					id->kind == lex::token::identifier ? ast::make_identifier(id) : ast::identifier{},
-					ast::type_as_expression(src_tokens, ast::make_auto_typespec(id))
+					context.auto_type_as_expression(src_tokens)
 				),
 				context.get_current_enclosing_scope()
 			);
@@ -139,7 +139,7 @@ static ast::decl_variable parse_decl_variable_id_and_type(
 			prototype,
 			ast::var_id_and_type(
 				id->kind == lex::token::identifier ? ast::make_identifier(id) : ast::identifier{},
-				ast::type_as_expression(lex::src_tokens::from_range(type), ast::make_unresolved_typespec(type))
+				context.type_as_expression(lex::src_tokens::from_range(type), ast::make_unresolved_typespec(type))
 			),
 			context.get_current_enclosing_scope()
 		);
@@ -1469,13 +1469,11 @@ static ast::statement parse_stmt_foreach_impl(
 
 	auto const outer_prev_size = context.add_unresolved_scope();
 
-	auto range_var_type = ast::make_auto_typespec(nullptr);
-	range_var_type.add_layer<ast::ts_auto_reference_mut>();
 	auto const range_expr_src_tokens = range_expr.src_tokens;
 	auto range_var_decl_stmt = ast::make_decl_variable(
 		range_expr_src_tokens,
 		lex::token_range{},
-		ast::var_id_and_type(ast::identifier{}, ast::type_as_expression(range_expr_src_tokens, std::move(range_var_type))),
+		ast::var_id_and_type(ast::identifier{}, ast::make_auto_typespec(nullptr)),
 		std::move(range_expr),
 		context.get_current_enclosing_scope()
 	);
@@ -1484,6 +1482,7 @@ static ast::statement parse_stmt_foreach_impl(
 	range_var_decl.id_and_type.id.tokens = { range_expr_src_tokens.begin, range_expr_src_tokens.end };
 	range_var_decl.id_and_type.id.values = { "" };
 	range_var_decl.id_and_type.id.is_qualified = false;
+	range_var_decl.id_and_type.var_type.add_layer<ast::ts_auto_reference_mut>();
 
 	auto const prev_in_loop = context.push_loop();
 	auto const inner_prev_size = context.add_unresolved_scope();

--- a/src/resolve/attribute_resolver.cpp
+++ b/src/resolve/attribute_resolver.cpp
@@ -137,22 +137,18 @@ static bool apply_builtin(
 	else if (alias_decl.id.values.back() == "isize")
 	{
 		auto const info = context.global_ctx.get_isize_type_info_for_builtin_alias();
-		alias_decl.alias_expr = ast::make_constant_expression(
+		alias_decl.alias_expr = context.type_as_expression(
 			alias_decl.alias_expr.src_tokens,
-			ast::expression_type_kind::type_name, ast::make_typename_typespec(nullptr),
-			ast::constant_value_storage(ast::make_base_type_typespec(alias_decl.alias_expr.src_tokens, info)),
-			ast::expr_t()
+			ast::make_base_type_typespec(alias_decl.alias_expr.src_tokens, info)
 		);
 		return true;
 	}
 	else if (alias_decl.id.values.back() == "usize")
 	{
 		auto const info = context.global_ctx.get_usize_type_info_for_builtin_alias();
-		alias_decl.alias_expr = ast::make_constant_expression(
+		alias_decl.alias_expr = context.type_as_expression(
 			alias_decl.alias_expr.src_tokens,
-			ast::expression_type_kind::type_name, ast::make_typename_typespec(nullptr),
-			ast::constant_value_storage(ast::make_base_type_typespec(alias_decl.alias_expr.src_tokens, info)),
-			ast::expr_t()
+			ast::make_base_type_typespec(alias_decl.alias_expr.src_tokens, info)
 		);
 		return true;
 	}

--- a/src/resolve/attribute_resolver.cpp
+++ b/src/resolve/attribute_resolver.cpp
@@ -140,7 +140,7 @@ static bool apply_builtin(
 		alias_decl.alias_expr = ast::make_constant_expression(
 			alias_decl.alias_expr.src_tokens,
 			ast::expression_type_kind::type_name, ast::make_typename_typespec(nullptr),
-			ast::constant_value(ast::make_base_type_typespec(alias_decl.alias_expr.src_tokens, info)),
+			ast::constant_value_storage(ast::make_base_type_typespec(alias_decl.alias_expr.src_tokens, info)),
 			ast::expr_t()
 		);
 		return true;
@@ -151,7 +151,7 @@ static bool apply_builtin(
 		alias_decl.alias_expr = ast::make_constant_expression(
 			alias_decl.alias_expr.src_tokens,
 			ast::expression_type_kind::type_name, ast::make_typename_typespec(nullptr),
-			ast::constant_value(ast::make_base_type_typespec(alias_decl.alias_expr.src_tokens, info)),
+			ast::constant_value_storage(ast::make_base_type_typespec(alias_decl.alias_expr.src_tokens, info)),
 			ast::expr_t()
 		);
 		return true;

--- a/src/resolve/consteval.cpp
+++ b/src/resolve/consteval.cpp
@@ -57,7 +57,7 @@ bool is_special_array_type(ast::typespec_view type)
 	}
 }
 
-static ast::constant_value_storage evaluate_binary_plus(
+static ast::constant_value evaluate_binary_plus(
 	ast::expression const &original_expr,
 	ast::expression const &lhs, ast::expression const &rhs,
 	ctx::parse_context &context
@@ -76,12 +76,12 @@ static ast::constant_value_storage evaluate_binary_plus(
 		auto const type = lhs_const_expr.type.remove_any_mut().get<ast::ts_base_type>().info->kind;
 		switch (lhs_value.kind())
 		{
-		static_assert(ast::constant_value_storage::variant_count == 19);
+		static_assert(ast::constant_value::variant_count == 19);
 		case ast::constant_value_kind::sint:
 		{
 			auto const lhs_int_val = lhs_value.get_sint();
 			auto const rhs_int_val = rhs_value.get_sint();
-			return ast::constant_value_storage(safe_binary_plus(
+			return ast::constant_value(safe_binary_plus(
 				original_expr.src_tokens, original_expr.paren_level,
 				lhs_int_val, rhs_int_val, type, context
 			));
@@ -90,7 +90,7 @@ static ast::constant_value_storage evaluate_binary_plus(
 		{
 			auto const lhs_int_val = lhs_value.get_uint();
 			auto const rhs_int_val = rhs_value.get_uint();
-			return ast::constant_value_storage(safe_binary_plus(
+			return ast::constant_value(safe_binary_plus(
 				original_expr.src_tokens, original_expr.paren_level,
 				lhs_int_val, rhs_int_val, type, context
 			));
@@ -99,7 +99,7 @@ static ast::constant_value_storage evaluate_binary_plus(
 		{
 			auto const lhs_float_val = lhs_value.get_float32();
 			auto const rhs_float_val = rhs_value.get_float32();
-			return ast::constant_value_storage(safe_binary_plus(
+			return ast::constant_value(safe_binary_plus(
 				original_expr.src_tokens, original_expr.paren_level,
 				lhs_float_val, rhs_float_val, context
 			));
@@ -108,7 +108,7 @@ static ast::constant_value_storage evaluate_binary_plus(
 		{
 			auto const lhs_float_val = lhs_value.get_float64();
 			auto const rhs_float_val = rhs_value.get_float64();
-			return ast::constant_value_storage(safe_binary_plus(
+			return ast::constant_value(safe_binary_plus(
 				original_expr.src_tokens, original_expr.paren_level,
 				lhs_float_val, rhs_float_val, context
 			));
@@ -134,7 +134,7 @@ static ast::constant_value_storage evaluate_binary_plus(
 			);
 		if (result.has_value())
 		{
-			return ast::constant_value_storage(result.get());
+			return ast::constant_value(result.get());
 		}
 		else
 		{
@@ -159,7 +159,7 @@ static ast::constant_value_storage evaluate_binary_plus(
 			);
 		if (result.has_value())
 		{
-			return ast::constant_value_storage(result.get());
+			return ast::constant_value(result.get());
 		}
 		else
 		{
@@ -168,7 +168,7 @@ static ast::constant_value_storage evaluate_binary_plus(
 	}
 }
 
-static ast::constant_value_storage evaluate_binary_minus(
+static ast::constant_value evaluate_binary_minus(
 	ast::expression const &original_expr,
 	ast::expression const &lhs, ast::expression const &rhs,
 	ctx::parse_context &context
@@ -187,12 +187,12 @@ static ast::constant_value_storage evaluate_binary_minus(
 		auto const type = lhs_const_expr.type.remove_any_mut().get<ast::ts_base_type>().info->kind;
 		switch (lhs_value.kind())
 		{
-		static_assert(ast::constant_value_storage::variant_count == 19);
+		static_assert(ast::constant_value::variant_count == 19);
 		case ast::constant_value_kind::sint:
 		{
 			auto const lhs_int_val = lhs_value.get_sint();
 			auto const rhs_int_val = rhs_value.get_sint();
-			return ast::constant_value_storage(safe_binary_minus(
+			return ast::constant_value(safe_binary_minus(
 				original_expr.src_tokens, original_expr.paren_level,
 				lhs_int_val, rhs_int_val, type, context
 			));
@@ -201,7 +201,7 @@ static ast::constant_value_storage evaluate_binary_minus(
 		{
 			auto const lhs_int_val = lhs_value.get_uint();
 			auto const rhs_int_val = rhs_value.get_uint();
-			return ast::constant_value_storage(safe_binary_minus(
+			return ast::constant_value(safe_binary_minus(
 				original_expr.src_tokens, original_expr.paren_level,
 				lhs_int_val, rhs_int_val, type, context
 			));
@@ -210,7 +210,7 @@ static ast::constant_value_storage evaluate_binary_minus(
 		{
 			auto const lhs_float_val = lhs_value.get_float32();
 			auto const rhs_float_val = rhs_value.get_float32();
-			return ast::constant_value_storage(safe_binary_minus(
+			return ast::constant_value(safe_binary_minus(
 				original_expr.src_tokens, original_expr.paren_level,
 				lhs_float_val, rhs_float_val, context
 			));
@@ -219,13 +219,13 @@ static ast::constant_value_storage evaluate_binary_minus(
 		{
 			auto const lhs_float_val = lhs_value.get_float64();
 			auto const rhs_float_val = rhs_value.get_float64();
-			return ast::constant_value_storage(safe_binary_minus(
+			return ast::constant_value(safe_binary_minus(
 				original_expr.src_tokens, original_expr.paren_level,
 				lhs_float_val, rhs_float_val, context
 			));
 		}
 		case ast::constant_value_kind::u8char:
-			return ast::constant_value_storage(
+			return ast::constant_value(
 				static_cast<int64_t>(lhs_value.get_u8char())
 				- static_cast<int64_t>(rhs_value.get_u8char())
 			);
@@ -251,7 +251,7 @@ static ast::constant_value_storage evaluate_binary_minus(
 			);
 		if (result.has_value())
 		{
-			return ast::constant_value_storage(result.get());
+			return ast::constant_value(result.get());
 		}
 		else
 		{
@@ -260,7 +260,7 @@ static ast::constant_value_storage evaluate_binary_minus(
 	}
 }
 
-static ast::constant_value_storage evaluate_binary_multiply(
+static ast::constant_value evaluate_binary_multiply(
 	ast::expression const &original_expr,
 	ast::expression const &lhs, ast::expression const &rhs,
 	ctx::parse_context &context
@@ -278,12 +278,12 @@ static ast::constant_value_storage evaluate_binary_multiply(
 	auto const type = lhs_const_expr.type.remove_any_mut().get<ast::ts_base_type>().info->kind;
 	switch (lhs_value.kind())
 	{
-	static_assert(ast::constant_value_storage::variant_count == 19);
+	static_assert(ast::constant_value::variant_count == 19);
 	case ast::constant_value_kind::sint:
 	{
 		auto const lhs_int_val = lhs_value.get_sint();
 		auto const rhs_int_val = rhs_value.get_sint();
-		return ast::constant_value_storage(safe_binary_multiply(
+		return ast::constant_value(safe_binary_multiply(
 			original_expr.src_tokens, original_expr.paren_level,
 			lhs_int_val, rhs_int_val, type, context
 		));
@@ -292,7 +292,7 @@ static ast::constant_value_storage evaluate_binary_multiply(
 	{
 		auto const lhs_int_val = lhs_value.get_uint();
 		auto const rhs_int_val = rhs_value.get_uint();
-		return ast::constant_value_storage(safe_binary_multiply(
+		return ast::constant_value(safe_binary_multiply(
 			original_expr.src_tokens, original_expr.paren_level,
 			lhs_int_val, rhs_int_val, type, context
 		));
@@ -301,7 +301,7 @@ static ast::constant_value_storage evaluate_binary_multiply(
 	{
 		auto const lhs_float_val = lhs_value.get_float32();
 		auto const rhs_float_val = rhs_value.get_float32();
-		return ast::constant_value_storage(safe_binary_multiply(
+		return ast::constant_value(safe_binary_multiply(
 			original_expr.src_tokens, original_expr.paren_level,
 			lhs_float_val, rhs_float_val, context
 		));
@@ -310,7 +310,7 @@ static ast::constant_value_storage evaluate_binary_multiply(
 	{
 		auto const lhs_float_val = lhs_value.get_float64();
 		auto const rhs_float_val = rhs_value.get_float64();
-		return ast::constant_value_storage(safe_binary_multiply(
+		return ast::constant_value(safe_binary_multiply(
 			original_expr.src_tokens, original_expr.paren_level,
 			lhs_float_val, rhs_float_val, context
 		));
@@ -320,7 +320,7 @@ static ast::constant_value_storage evaluate_binary_multiply(
 	}
 }
 
-static ast::constant_value_storage evaluate_binary_divide(
+static ast::constant_value evaluate_binary_divide(
 	ast::expression const &original_expr,
 	ast::expression const &lhs, ast::expression const &rhs,
 	ctx::parse_context &context
@@ -338,7 +338,7 @@ static ast::constant_value_storage evaluate_binary_divide(
 	auto const type = lhs_const_expr.type.remove_any_mut().get<ast::ts_base_type>().info->kind;
 	switch (lhs_value.kind())
 	{
-	static_assert(ast::constant_value_storage::variant_count == 19);
+	static_assert(ast::constant_value::variant_count == 19);
 	case ast::constant_value_kind::sint:
 	{
 		auto const lhs_int_val = lhs_value.get_sint();
@@ -349,7 +349,7 @@ static ast::constant_value_storage evaluate_binary_divide(
 		);
 		if (result.has_value())
 		{
-			return ast::constant_value_storage(result.get());
+			return ast::constant_value(result.get());
 		}
 		else
 		{
@@ -366,7 +366,7 @@ static ast::constant_value_storage evaluate_binary_divide(
 		);
 		if (result.has_value())
 		{
-			return ast::constant_value_storage(result.get());
+			return ast::constant_value(result.get());
 		}
 		else
 		{
@@ -377,7 +377,7 @@ static ast::constant_value_storage evaluate_binary_divide(
 	{
 		auto const lhs_float_val = lhs_value.get_float32();
 		auto const rhs_float_val = rhs_value.get_float32();
-		return ast::constant_value_storage(safe_binary_divide(
+		return ast::constant_value(safe_binary_divide(
 			original_expr.src_tokens, original_expr.paren_level,
 			lhs_float_val, rhs_float_val, context
 		));
@@ -386,7 +386,7 @@ static ast::constant_value_storage evaluate_binary_divide(
 	{
 		auto const lhs_float_val = lhs_value.get_float64();
 		auto const rhs_float_val = rhs_value.get_float64();
-		return ast::constant_value_storage(safe_binary_divide(
+		return ast::constant_value(safe_binary_divide(
 			original_expr.src_tokens, original_expr.paren_level,
 			lhs_float_val, rhs_float_val, context
 		));
@@ -396,7 +396,7 @@ static ast::constant_value_storage evaluate_binary_divide(
 	}
 }
 
-static ast::constant_value_storage evaluate_binary_modulo(
+static ast::constant_value evaluate_binary_modulo(
 	ast::expression const &original_expr,
 	ast::expression const &lhs, ast::expression const &rhs,
 	ctx::parse_context &context
@@ -414,7 +414,7 @@ static ast::constant_value_storage evaluate_binary_modulo(
 	auto const type = lhs_const_expr.type.remove_any_mut().get<ast::ts_base_type>().info->kind;
 	switch (lhs_value.kind())
 	{
-	static_assert(ast::constant_value_storage::variant_count == 19);
+	static_assert(ast::constant_value::variant_count == 19);
 	case ast::constant_value_kind::sint:
 	{
 		auto const lhs_int_val = lhs_value.get_sint();
@@ -425,7 +425,7 @@ static ast::constant_value_storage evaluate_binary_modulo(
 		);
 		if (result.has_value())
 		{
-			return ast::constant_value_storage(result.get());
+			return ast::constant_value(result.get());
 		}
 		else
 		{
@@ -442,7 +442,7 @@ static ast::constant_value_storage evaluate_binary_modulo(
 		);
 		if (result.has_value())
 		{
-			return ast::constant_value_storage(result.get());
+			return ast::constant_value(result.get());
 		}
 		else
 		{
@@ -454,7 +454,7 @@ static ast::constant_value_storage evaluate_binary_modulo(
 	}
 }
 
-static ast::constant_value_storage evaluate_binary_equals(
+static ast::constant_value evaluate_binary_equals(
 	[[maybe_unused]] ast::expression const &original_expr,
 	ast::expression const &lhs, ast::expression const &rhs,
 	[[maybe_unused]] ctx::parse_context &context
@@ -471,24 +471,24 @@ static ast::constant_value_storage evaluate_binary_equals(
 
 	switch (lhs_value.kind())
 	{
-	static_assert(ast::constant_value_storage::variant_count == 19);
+	static_assert(ast::constant_value::variant_count == 19);
 	case ast::constant_value_kind::sint:
 	{
 		auto const lhs_int_val = lhs_value.get_sint();
 		auto const rhs_int_val = rhs_value.get_sint();
-		return ast::constant_value_storage(lhs_int_val == rhs_int_val);
+		return ast::constant_value(lhs_int_val == rhs_int_val);
 	}
 	case ast::constant_value_kind::uint:
 	{
 		auto const lhs_int_val = lhs_value.get_uint();
 		auto const rhs_int_val = rhs_value.get_uint();
-		return ast::constant_value_storage(lhs_int_val == rhs_int_val);
+		return ast::constant_value(lhs_int_val == rhs_int_val);
 	}
 	case ast::constant_value_kind::float32:
 	{
 		auto const lhs_float_val = lhs_value.get_float32();
 		auto const rhs_float_val = rhs_value.get_float32();
-		return ast::constant_value_storage(safe_binary_equals(
+		return ast::constant_value(safe_binary_equals(
 			original_expr.src_tokens, original_expr.paren_level,
 			lhs_float_val, rhs_float_val, context
 		));
@@ -497,7 +497,7 @@ static ast::constant_value_storage evaluate_binary_equals(
 	{
 		auto const lhs_float_val = lhs_value.get_float64();
 		auto const rhs_float_val = rhs_value.get_float64();
-		return ast::constant_value_storage(safe_binary_equals(
+		return ast::constant_value(safe_binary_equals(
 			original_expr.src_tokens, original_expr.paren_level,
 			lhs_float_val, rhs_float_val, context
 		));
@@ -506,36 +506,36 @@ static ast::constant_value_storage evaluate_binary_equals(
 	{
 		auto const lhs_char_val = lhs_value.get_u8char();
 		auto const rhs_char_val = rhs_value.get_u8char();
-		return ast::constant_value_storage(lhs_char_val == rhs_char_val);
+		return ast::constant_value(lhs_char_val == rhs_char_val);
 	}
 	case ast::constant_value_kind::boolean:
 	{
 		auto const lhs_bool_val = lhs_value.get_boolean();
 		auto const rhs_bool_val = rhs_value.get_boolean();
-		return ast::constant_value_storage(lhs_bool_val == rhs_bool_val);
+		return ast::constant_value(lhs_bool_val == rhs_bool_val);
 	}
 	case ast::constant_value_kind::string:
 	{
 		auto const lhs_str_val = lhs_value.get_string();
 		auto const rhs_str_val = rhs_value.get_string();
-		return ast::constant_value_storage(lhs_str_val == rhs_str_val);
+		return ast::constant_value(lhs_str_val == rhs_str_val);
 	}
 	case ast::constant_value_kind::null:
 	{
-		return ast::constant_value_storage(true);
+		return ast::constant_value(true);
 	}
 	case ast::constant_value_kind::enum_:
 	{
 		auto const lhs_enum_value = lhs_value.get_enum().value;
 		auto const rhs_enum_value = rhs_value.get_enum().value;
-		return ast::constant_value_storage(lhs_enum_value == rhs_enum_value);
+		return ast::constant_value(lhs_enum_value == rhs_enum_value);
 	}
 	default:
 		bz_unreachable;
 	}
 }
 
-static ast::constant_value_storage evaluate_binary_not_equals(
+static ast::constant_value evaluate_binary_not_equals(
 	[[maybe_unused]] ast::expression const &original_expr,
 	ast::expression const &lhs, ast::expression const &rhs,
 	[[maybe_unused]] ctx::parse_context &context
@@ -552,65 +552,65 @@ static ast::constant_value_storage evaluate_binary_not_equals(
 
 	switch (lhs_value.kind())
 	{
-	static_assert(ast::constant_value_storage::variant_count == 19);
+	static_assert(ast::constant_value::variant_count == 19);
 	case ast::constant_value_kind::sint:
 	{
 		auto const lhs_int_val = lhs_value.get_sint();
 		auto const rhs_int_val = rhs_value.get_sint();
-		return ast::constant_value_storage(lhs_int_val != rhs_int_val);
+		return ast::constant_value(lhs_int_val != rhs_int_val);
 	}
 	case ast::constant_value_kind::uint:
 	{
 		auto const lhs_int_val = lhs_value.get_uint();
 		auto const rhs_int_val = rhs_value.get_uint();
-		return ast::constant_value_storage(lhs_int_val != rhs_int_val);
+		return ast::constant_value(lhs_int_val != rhs_int_val);
 	}
 	case ast::constant_value_kind::float32:
 	{
 		auto const lhs_float_val = lhs_value.get_float32();
 		auto const rhs_float_val = rhs_value.get_float32();
-		return ast::constant_value_storage(lhs_float_val != rhs_float_val);
+		return ast::constant_value(lhs_float_val != rhs_float_val);
 	}
 	case ast::constant_value_kind::float64:
 	{
 		auto const lhs_float_val = lhs_value.get_float64();
 		auto const rhs_float_val = rhs_value.get_float64();
-		return ast::constant_value_storage(lhs_float_val != rhs_float_val);
+		return ast::constant_value(lhs_float_val != rhs_float_val);
 	}
 	case ast::constant_value_kind::u8char:
 	{
 		auto const lhs_char_val = lhs_value.get_u8char();
 		auto const rhs_char_val = rhs_value.get_u8char();
-		return ast::constant_value_storage(lhs_char_val != rhs_char_val);
+		return ast::constant_value(lhs_char_val != rhs_char_val);
 	}
 	case ast::constant_value_kind::boolean:
 	{
 		auto const lhs_bool_val = lhs_value.get_boolean();
 		auto const rhs_bool_val = rhs_value.get_boolean();
-		return ast::constant_value_storage(lhs_bool_val != rhs_bool_val);
+		return ast::constant_value(lhs_bool_val != rhs_bool_val);
 	}
 	case ast::constant_value_kind::string:
 	{
 		auto const lhs_str_val = lhs_value.get_string();
 		auto const rhs_str_val = rhs_value.get_string();
-		return ast::constant_value_storage(lhs_str_val != rhs_str_val);
+		return ast::constant_value(lhs_str_val != rhs_str_val);
 	}
 	case ast::constant_value_kind::null:
 	{
-		return ast::constant_value_storage(false);
+		return ast::constant_value(false);
 	}
 	case ast::constant_value_kind::enum_:
 	{
 		auto const lhs_enum_value = lhs_value.get_enum().value;
 		auto const rhs_enum_value = rhs_value.get_enum().value;
-		return ast::constant_value_storage(lhs_enum_value != rhs_enum_value);
+		return ast::constant_value(lhs_enum_value != rhs_enum_value);
 	}
 	default:
 		bz_unreachable;
 	}
 }
 
-static ast::constant_value_storage evaluate_binary_less_than(
+static ast::constant_value evaluate_binary_less_than(
 	[[maybe_unused]] ast::expression const &original_expr,
 	ast::expression const &lhs, ast::expression const &rhs,
 	[[maybe_unused]] ctx::parse_context &context
@@ -627,40 +627,40 @@ static ast::constant_value_storage evaluate_binary_less_than(
 
 	switch (lhs_value.kind())
 	{
-	static_assert(ast::constant_value_storage::variant_count == 19);
+	static_assert(ast::constant_value::variant_count == 19);
 	case ast::constant_value_kind::sint:
 	{
 		auto const lhs_int_val = lhs_value.get_sint();
 		auto const rhs_int_val = rhs_value.get_sint();
-		return ast::constant_value_storage(lhs_int_val < rhs_int_val);
+		return ast::constant_value(lhs_int_val < rhs_int_val);
 	}
 	case ast::constant_value_kind::uint:
 	{
 		auto const lhs_int_val = lhs_value.get_uint();
 		auto const rhs_int_val = rhs_value.get_uint();
-		return ast::constant_value_storage(lhs_int_val < rhs_int_val);
+		return ast::constant_value(lhs_int_val < rhs_int_val);
 	}
 	case ast::constant_value_kind::float32:
 	{
 		auto const lhs_float_val = lhs_value.get_float32();
 		auto const rhs_float_val = rhs_value.get_float32();
-		return ast::constant_value_storage(lhs_float_val < rhs_float_val);
+		return ast::constant_value(lhs_float_val < rhs_float_val);
 	}
 	case ast::constant_value_kind::float64:
 	{
 		auto const lhs_float_val = lhs_value.get_float64();
 		auto const rhs_float_val = rhs_value.get_float64();
-		return ast::constant_value_storage(lhs_float_val < rhs_float_val);
+		return ast::constant_value(lhs_float_val < rhs_float_val);
 	}
 	case ast::constant_value_kind::u8char:
 	{
 		auto const lhs_char_val = lhs_value.get_u8char();
 		auto const rhs_char_val = rhs_value.get_u8char();
-		return ast::constant_value_storage(lhs_char_val < rhs_char_val);
+		return ast::constant_value(lhs_char_val < rhs_char_val);
 	}
 	case ast::constant_value_kind::null:
 	{
-		return ast::constant_value_storage(false);
+		return ast::constant_value(false);
 	}
 	case ast::constant_value_kind::enum_:
 	{
@@ -668,15 +668,15 @@ static ast::constant_value_storage evaluate_binary_less_than(
 		auto const rhs_enum_value = rhs_value.get_enum().value;
 		auto const is_signed = ast::is_signed_integer_kind(decl->underlying_type.get<ast::ts_base_type>().info->kind);
 		return is_signed
-			? ast::constant_value_storage(bit_cast<int64_t>(lhs_enum_value) < bit_cast<int64_t>(rhs_enum_value))
-			: ast::constant_value_storage(lhs_enum_value < rhs_enum_value);
+			? ast::constant_value(bit_cast<int64_t>(lhs_enum_value) < bit_cast<int64_t>(rhs_enum_value))
+			: ast::constant_value(lhs_enum_value < rhs_enum_value);
 	}
 	default:
 		bz_unreachable;
 	}
 }
 
-static ast::constant_value_storage evaluate_binary_less_than_eq(
+static ast::constant_value evaluate_binary_less_than_eq(
 	[[maybe_unused]] ast::expression const &original_expr,
 	ast::expression const &lhs, ast::expression const &rhs,
 	[[maybe_unused]] ctx::parse_context &context
@@ -693,40 +693,40 @@ static ast::constant_value_storage evaluate_binary_less_than_eq(
 
 	switch (lhs_value.kind())
 	{
-	static_assert(ast::constant_value_storage::variant_count == 19);
+	static_assert(ast::constant_value::variant_count == 19);
 	case ast::constant_value_kind::sint:
 	{
 		auto const lhs_int_val = lhs_value.get_sint();
 		auto const rhs_int_val = rhs_value.get_sint();
-		return ast::constant_value_storage(lhs_int_val <= rhs_int_val);
+		return ast::constant_value(lhs_int_val <= rhs_int_val);
 	}
 	case ast::constant_value_kind::uint:
 	{
 		auto const lhs_int_val = lhs_value.get_uint();
 		auto const rhs_int_val = rhs_value.get_uint();
-		return ast::constant_value_storage(lhs_int_val <= rhs_int_val);
+		return ast::constant_value(lhs_int_val <= rhs_int_val);
 	}
 	case ast::constant_value_kind::float32:
 	{
 		auto const lhs_float_val = lhs_value.get_float32();
 		auto const rhs_float_val = rhs_value.get_float32();
-		return ast::constant_value_storage(lhs_float_val <= rhs_float_val);
+		return ast::constant_value(lhs_float_val <= rhs_float_val);
 	}
 	case ast::constant_value_kind::float64:
 	{
 		auto const lhs_float_val = lhs_value.get_float64();
 		auto const rhs_float_val = rhs_value.get_float64();
-		return ast::constant_value_storage(lhs_float_val <= rhs_float_val);
+		return ast::constant_value(lhs_float_val <= rhs_float_val);
 	}
 	case ast::constant_value_kind::u8char:
 	{
 		auto const lhs_char_val = lhs_value.get_u8char();
 		auto const rhs_char_val = rhs_value.get_u8char();
-		return ast::constant_value_storage(lhs_char_val <= rhs_char_val);
+		return ast::constant_value(lhs_char_val <= rhs_char_val);
 	}
 	case ast::constant_value_kind::null:
 	{
-		return ast::constant_value_storage(true);
+		return ast::constant_value(true);
 	}
 	case ast::constant_value_kind::enum_:
 	{
@@ -734,15 +734,15 @@ static ast::constant_value_storage evaluate_binary_less_than_eq(
 		auto const rhs_enum_value = rhs_value.get_enum().value;
 		auto const is_signed = ast::is_signed_integer_kind(decl->underlying_type.get<ast::ts_base_type>().info->kind);
 		return is_signed
-			? ast::constant_value_storage(bit_cast<int64_t>(lhs_enum_value) <= bit_cast<int64_t>(rhs_enum_value))
-			: ast::constant_value_storage(lhs_enum_value <= rhs_enum_value);
+			? ast::constant_value(bit_cast<int64_t>(lhs_enum_value) <= bit_cast<int64_t>(rhs_enum_value))
+			: ast::constant_value(lhs_enum_value <= rhs_enum_value);
 	}
 	default:
 		bz_unreachable;
 	}
 }
 
-static ast::constant_value_storage evaluate_binary_greater_than(
+static ast::constant_value evaluate_binary_greater_than(
 	[[maybe_unused]] ast::expression const &original_expr,
 	ast::expression const &lhs, ast::expression const &rhs,
 	[[maybe_unused]] ctx::parse_context &context
@@ -759,40 +759,40 @@ static ast::constant_value_storage evaluate_binary_greater_than(
 
 	switch (lhs_value.kind())
 	{
-	static_assert(ast::constant_value_storage::variant_count == 19);
+	static_assert(ast::constant_value::variant_count == 19);
 	case ast::constant_value_kind::sint:
 	{
 		auto const lhs_int_val = lhs_value.get_sint();
 		auto const rhs_int_val = rhs_value.get_sint();
-		return ast::constant_value_storage(lhs_int_val > rhs_int_val);
+		return ast::constant_value(lhs_int_val > rhs_int_val);
 	}
 	case ast::constant_value_kind::uint:
 	{
 		auto const lhs_int_val = lhs_value.get_uint();
 		auto const rhs_int_val = rhs_value.get_uint();
-		return ast::constant_value_storage(lhs_int_val > rhs_int_val);
+		return ast::constant_value(lhs_int_val > rhs_int_val);
 	}
 	case ast::constant_value_kind::float32:
 	{
 		auto const lhs_float_val = lhs_value.get_float32();
 		auto const rhs_float_val = rhs_value.get_float32();
-		return ast::constant_value_storage(lhs_float_val > rhs_float_val);
+		return ast::constant_value(lhs_float_val > rhs_float_val);
 	}
 	case ast::constant_value_kind::float64:
 	{
 		auto const lhs_float_val = lhs_value.get_float64();
 		auto const rhs_float_val = rhs_value.get_float64();
-		return ast::constant_value_storage(lhs_float_val > rhs_float_val);
+		return ast::constant_value(lhs_float_val > rhs_float_val);
 	}
 	case ast::constant_value_kind::u8char:
 	{
 		auto const lhs_char_val = lhs_value.get_u8char();
 		auto const rhs_char_val = rhs_value.get_u8char();
-		return ast::constant_value_storage(lhs_char_val > rhs_char_val);
+		return ast::constant_value(lhs_char_val > rhs_char_val);
 	}
 	case ast::constant_value_kind::null:
 	{
-		return ast::constant_value_storage(false);
+		return ast::constant_value(false);
 	}
 	case ast::constant_value_kind::enum_:
 	{
@@ -800,15 +800,15 @@ static ast::constant_value_storage evaluate_binary_greater_than(
 		auto const rhs_enum_value = rhs_value.get_enum().value;
 		auto const is_signed = ast::is_signed_integer_kind(decl->underlying_type.get<ast::ts_base_type>().info->kind);
 		return is_signed
-			? ast::constant_value_storage(bit_cast<int64_t>(lhs_enum_value) > bit_cast<int64_t>(rhs_enum_value))
-			: ast::constant_value_storage(lhs_enum_value > rhs_enum_value);
+			? ast::constant_value(bit_cast<int64_t>(lhs_enum_value) > bit_cast<int64_t>(rhs_enum_value))
+			: ast::constant_value(lhs_enum_value > rhs_enum_value);
 	}
 	default:
 		bz_unreachable;
 	}
 }
 
-static ast::constant_value_storage evaluate_binary_greater_than_eq(
+static ast::constant_value evaluate_binary_greater_than_eq(
 	[[maybe_unused]] ast::expression const &original_expr,
 	ast::expression const &lhs, ast::expression const &rhs,
 	[[maybe_unused]] ctx::parse_context &context
@@ -825,40 +825,40 @@ static ast::constant_value_storage evaluate_binary_greater_than_eq(
 
 	switch (lhs_value.kind())
 	{
-	static_assert(ast::constant_value_storage::variant_count == 19);
+	static_assert(ast::constant_value::variant_count == 19);
 	case ast::constant_value_kind::sint:
 	{
 		auto const lhs_int_val = lhs_value.get_sint();
 		auto const rhs_int_val = rhs_value.get_sint();
-		return ast::constant_value_storage(lhs_int_val >= rhs_int_val);
+		return ast::constant_value(lhs_int_val >= rhs_int_val);
 	}
 	case ast::constant_value_kind::uint:
 	{
 		auto const lhs_int_val = lhs_value.get_uint();
 		auto const rhs_int_val = rhs_value.get_uint();
-		return ast::constant_value_storage(lhs_int_val >= rhs_int_val);
+		return ast::constant_value(lhs_int_val >= rhs_int_val);
 	}
 	case ast::constant_value_kind::float32:
 	{
 		auto const lhs_float_val = lhs_value.get_float32();
 		auto const rhs_float_val = rhs_value.get_float32();
-		return ast::constant_value_storage(lhs_float_val >= rhs_float_val);
+		return ast::constant_value(lhs_float_val >= rhs_float_val);
 	}
 	case ast::constant_value_kind::float64:
 	{
 		auto const lhs_float_val = lhs_value.get_float64();
 		auto const rhs_float_val = rhs_value.get_float64();
-		return ast::constant_value_storage(lhs_float_val >= rhs_float_val);
+		return ast::constant_value(lhs_float_val >= rhs_float_val);
 	}
 	case ast::constant_value_kind::u8char:
 	{
 		auto const lhs_char_val = lhs_value.get_u8char();
 		auto const rhs_char_val = rhs_value.get_u8char();
-		return ast::constant_value_storage(lhs_char_val >= rhs_char_val);
+		return ast::constant_value(lhs_char_val >= rhs_char_val);
 	}
 	case ast::constant_value_kind::null:
 	{
-		return ast::constant_value_storage(true);
+		return ast::constant_value(true);
 	}
 	case ast::constant_value_kind::enum_:
 	{
@@ -866,15 +866,15 @@ static ast::constant_value_storage evaluate_binary_greater_than_eq(
 		auto const rhs_enum_value = rhs_value.get_enum().value;
 		auto const is_signed = ast::is_signed_integer_kind(decl->underlying_type.get<ast::ts_base_type>().info->kind);
 		return is_signed
-			? ast::constant_value_storage(bit_cast<int64_t>(lhs_enum_value) >= bit_cast<int64_t>(rhs_enum_value))
-			: ast::constant_value_storage(lhs_enum_value >= rhs_enum_value);
+			? ast::constant_value(bit_cast<int64_t>(lhs_enum_value) >= bit_cast<int64_t>(rhs_enum_value))
+			: ast::constant_value(lhs_enum_value >= rhs_enum_value);
 	}
 	default:
 		bz_unreachable;
 	}
 }
 
-static ast::constant_value_storage evaluate_binary_bit_and(
+static ast::constant_value evaluate_binary_bit_and(
 	[[maybe_unused]] ast::expression const &original_expr,
 	ast::expression const &lhs, ast::expression const &rhs,
 	[[maybe_unused]] ctx::parse_context &context
@@ -891,25 +891,25 @@ static ast::constant_value_storage evaluate_binary_bit_and(
 
 	switch (lhs_value.kind())
 	{
-	static_assert(ast::constant_value_storage::variant_count == 19);
+	static_assert(ast::constant_value::variant_count == 19);
 	case ast::constant_value_kind::uint:
 	{
 		auto const lhs_int_val = lhs_value.get_uint();
 		auto const rhs_int_val = rhs_value.get_uint();
-		return ast::constant_value_storage(lhs_int_val & rhs_int_val);
+		return ast::constant_value(lhs_int_val & rhs_int_val);
 	}
 	case ast::constant_value_kind::boolean:
 	{
 		auto const lhs_bool_val = lhs_value.get_boolean();
 		auto const rhs_bool_val = rhs_value.get_boolean();
-		return ast::constant_value_storage(lhs_bool_val && rhs_bool_val);
+		return ast::constant_value(lhs_bool_val && rhs_bool_val);
 	}
 	default:
 		bz_unreachable;
 	}
 }
 
-static ast::constant_value_storage evaluate_binary_bit_xor(
+static ast::constant_value evaluate_binary_bit_xor(
 	[[maybe_unused]] ast::expression const &original_expr,
 	ast::expression const &lhs, ast::expression const &rhs,
 	[[maybe_unused]] ctx::parse_context &context
@@ -926,25 +926,25 @@ static ast::constant_value_storage evaluate_binary_bit_xor(
 
 	switch (lhs_value.kind())
 	{
-	static_assert(ast::constant_value_storage::variant_count == 19);
+	static_assert(ast::constant_value::variant_count == 19);
 	case ast::constant_value_kind::uint:
 	{
 		auto const lhs_int_val = lhs_value.get_uint();
 		auto const rhs_int_val = rhs_value.get_uint();
-		return ast::constant_value_storage(lhs_int_val ^ rhs_int_val);
+		return ast::constant_value(lhs_int_val ^ rhs_int_val);
 	}
 	case ast::constant_value_kind::boolean:
 	{
 		auto const lhs_bool_val = lhs_value.get_boolean();
 		auto const rhs_bool_val = rhs_value.get_boolean();
-		return ast::constant_value_storage(lhs_bool_val != rhs_bool_val);
+		return ast::constant_value(lhs_bool_val != rhs_bool_val);
 	}
 	default:
 		bz_unreachable;
 	}
 }
 
-static ast::constant_value_storage evaluate_binary_bit_or(
+static ast::constant_value evaluate_binary_bit_or(
 	[[maybe_unused]] ast::expression const &original_expr,
 	ast::expression const &lhs, ast::expression const &rhs,
 	[[maybe_unused]] ctx::parse_context &context
@@ -961,25 +961,25 @@ static ast::constant_value_storage evaluate_binary_bit_or(
 
 	switch (lhs_value.kind())
 	{
-	static_assert(ast::constant_value_storage::variant_count == 19);
+	static_assert(ast::constant_value::variant_count == 19);
 	case ast::constant_value_kind::uint:
 	{
 		auto const lhs_int_val = lhs_value.get_uint();
 		auto const rhs_int_val = rhs_value.get_uint();
-		return ast::constant_value_storage(lhs_int_val | rhs_int_val);
+		return ast::constant_value(lhs_int_val | rhs_int_val);
 	}
 	case ast::constant_value_kind::boolean:
 	{
 		auto const lhs_bool_val = lhs_value.get_boolean();
 		auto const rhs_bool_val = rhs_value.get_boolean();
-		return ast::constant_value_storage(lhs_bool_val || rhs_bool_val);
+		return ast::constant_value(lhs_bool_val || rhs_bool_val);
 	}
 	default:
 		bz_unreachable;
 	}
 }
 
-static ast::constant_value_storage evaluate_binary_bit_left_shift(
+static ast::constant_value evaluate_binary_bit_left_shift(
 	ast::expression const &original_expr,
 	ast::expression const &lhs, ast::expression const &rhs,
 	ctx::parse_context &context
@@ -1010,7 +1010,7 @@ static ast::constant_value_storage evaluate_binary_bit_left_shift(
 		);
 		if (result.has_value())
 		{
-			return ast::constant_value_storage(result.get());
+			return ast::constant_value(result.get());
 		}
 		else
 		{
@@ -1028,7 +1028,7 @@ static ast::constant_value_storage evaluate_binary_bit_left_shift(
 		);
 		if (result.has_value())
 		{
-			return ast::constant_value_storage(result.get());
+			return ast::constant_value(result.get());
 		}
 		else
 		{
@@ -1037,7 +1037,7 @@ static ast::constant_value_storage evaluate_binary_bit_left_shift(
 	}
 }
 
-static ast::constant_value_storage evaluate_binary_bit_right_shift(
+static ast::constant_value evaluate_binary_bit_right_shift(
 	ast::expression const &original_expr,
 	ast::expression const &lhs, ast::expression const &rhs,
 	ctx::parse_context &context
@@ -1068,7 +1068,7 @@ static ast::constant_value_storage evaluate_binary_bit_right_shift(
 		);
 		if (result.has_value())
 		{
-			return ast::constant_value_storage(result.get());
+			return ast::constant_value(result.get());
 		}
 		else
 		{
@@ -1086,7 +1086,7 @@ static ast::constant_value_storage evaluate_binary_bit_right_shift(
 		);
 		if (result.has_value())
 		{
-			return ast::constant_value_storage(result.get());
+			return ast::constant_value(result.get());
 		}
 		else
 		{
@@ -1095,7 +1095,7 @@ static ast::constant_value_storage evaluate_binary_bit_right_shift(
 	}
 }
 
-static ast::constant_value_storage evaluate_binary_bool_and(
+static ast::constant_value evaluate_binary_bool_and(
 	[[maybe_unused]] ast::expression const &original_expr,
 	ast::expression const &lhs, ast::expression const &rhs,
 	[[maybe_unused]] ctx::parse_context &context
@@ -1115,10 +1115,10 @@ static ast::constant_value_storage evaluate_binary_bool_and(
 
 	// short-circuiting is handled elsewhere
 	bz_assert(lhs_bool_val);
-	return ast::constant_value_storage(rhs_bool_val);
+	return ast::constant_value(rhs_bool_val);
 }
 
-static ast::constant_value_storage evaluate_binary_bool_xor(
+static ast::constant_value evaluate_binary_bool_xor(
 	[[maybe_unused]] ast::expression const &original_expr,
 	ast::expression const &lhs, ast::expression const &rhs,
 	[[maybe_unused]] ctx::parse_context &context
@@ -1136,10 +1136,10 @@ static ast::constant_value_storage evaluate_binary_bool_xor(
 	bz_assert(rhs_value.is_boolean());
 	auto const rhs_bool_val = rhs_value.get_boolean();
 
-	return ast::constant_value_storage(lhs_bool_val != rhs_bool_val);
+	return ast::constant_value(lhs_bool_val != rhs_bool_val);
 }
 
-static ast::constant_value_storage evaluate_binary_bool_or(
+static ast::constant_value evaluate_binary_bool_or(
 	[[maybe_unused]] ast::expression const &original_expr,
 	ast::expression const &lhs, ast::expression const &rhs,
 	[[maybe_unused]] ctx::parse_context &context
@@ -1159,10 +1159,10 @@ static ast::constant_value_storage evaluate_binary_bool_or(
 
 	// short-circuiting is handled elsewhere
 	bz_assert(!lhs_bool_val);
-	return ast::constant_value_storage(rhs_bool_val);
+	return ast::constant_value(rhs_bool_val);
 }
 
-static ast::constant_value_storage evaluate_binary_comma(
+static ast::constant_value evaluate_binary_comma(
 	[[maybe_unused]] ast::expression const &original_expr,
 	[[maybe_unused]] ast::expression const &lhs, ast::expression const &rhs,
 	[[maybe_unused]] ctx::parse_context &context
@@ -1173,7 +1173,7 @@ static ast::constant_value_storage evaluate_binary_comma(
 }
 
 
-static ast::constant_value_storage evaluate_binary_op(
+static ast::constant_value evaluate_binary_op(
 	ast::expression const &original_expr,
 	uint32_t op, ast::expression const &lhs, ast::expression const &rhs,
 	ctx::parse_context &context
@@ -1226,7 +1226,7 @@ static ast::constant_value_storage evaluate_binary_op(
 	}
 }
 
-static ast::constant_value_storage evaluate_tuple_subscript(ast::expr_tuple_subscript const &tuple_subscript_expr)
+static ast::constant_value evaluate_tuple_subscript(ast::expr_tuple_subscript const &tuple_subscript_expr)
 {
 	bz_assert(tuple_subscript_expr.index.is<ast::constant_expression>());
 	auto const is_consteval = tuple_subscript_expr.base.elems
@@ -1249,7 +1249,7 @@ static ast::constant_value_storage evaluate_tuple_subscript(ast::expr_tuple_subs
 	return tuple_subscript_expr.base.elems[index_int_value].get_constant_value();
 }
 
-static ast::constant_value_storage evaluate_subscript(
+static ast::constant_value evaluate_subscript(
 	ast::expression const &base,
 	ast::expression const &index,
 	ctx::parse_context &context
@@ -1344,12 +1344,12 @@ static ast::constant_value_storage evaluate_subscript(
 			auto const end_index = begin_index + inner_size;
 			switch (value.kind())
 			{
-			static_assert(ast::constant_value_storage::variant_count == 19);
+			static_assert(ast::constant_value::variant_count == 19);
 			case ast::constant_value_kind::array:
 			{
 				auto const &array_value = value.get_array();
 				bz_assert(end_index <= array_value.size());
-				auto result = ast::constant_value_storage();
+				auto result = ast::constant_value();
 				result.emplace<ast::constant_value_kind::array>(array_value.slice(begin_index, end_index));
 				return result;
 			}
@@ -1357,7 +1357,7 @@ static ast::constant_value_storage evaluate_subscript(
 			{
 				auto const &array_value = value.get_sint_array();
 				bz_assert(end_index <= array_value.size());
-				auto result = ast::constant_value_storage();
+				auto result = ast::constant_value();
 				result.emplace<ast::constant_value_kind::sint_array>(array_value.slice(begin_index, end_index));
 				return result;
 			}
@@ -1365,7 +1365,7 @@ static ast::constant_value_storage evaluate_subscript(
 			{
 				auto const &array_value = value.get_uint_array();
 				bz_assert(end_index <= array_value.size());
-				auto result = ast::constant_value_storage();
+				auto result = ast::constant_value();
 				result.emplace<ast::constant_value_kind::uint_array>(array_value.slice(begin_index, end_index));
 				return result;
 			}
@@ -1373,7 +1373,7 @@ static ast::constant_value_storage evaluate_subscript(
 			{
 				auto const &array_value = value.get_float32_array();
 				bz_assert(end_index <= array_value.size());
-				auto result = ast::constant_value_storage();
+				auto result = ast::constant_value();
 				result.emplace<ast::constant_value_kind::float32_array>(array_value.slice(begin_index, end_index));
 				return result;
 			}
@@ -1381,7 +1381,7 @@ static ast::constant_value_storage evaluate_subscript(
 			{
 				auto const &array_value = value.get_float64_array();
 				bz_assert(end_index <= array_value.size());
-				auto result = ast::constant_value_storage();
+				auto result = ast::constant_value();
 				result.emplace<ast::constant_value_kind::float64_array>(array_value.slice(begin_index, end_index));
 				return result;
 			}
@@ -1393,7 +1393,7 @@ static ast::constant_value_storage evaluate_subscript(
 		{
 			switch (value.kind())
 			{
-			static_assert(ast::constant_value_storage::variant_count == 19);
+			static_assert(ast::constant_value::variant_count == 19);
 			case ast::constant_value_kind::array:
 			{
 				auto const &array_value = value.get_array();
@@ -1404,25 +1404,25 @@ static ast::constant_value_storage evaluate_subscript(
 			{
 				auto const &array_value = value.get_sint_array();
 				bz_assert(index_value < array_value.size());
-				return ast::constant_value_storage(array_value[index_value]);
+				return ast::constant_value(array_value[index_value]);
 			}
 			case ast::constant_value_kind::uint_array:
 			{
 				auto const &array_value = value.get_uint_array();
 				bz_assert(index_value < array_value.size());
-				return ast::constant_value_storage(array_value[index_value]);
+				return ast::constant_value(array_value[index_value]);
 			}
 			case ast::constant_value_kind::float32_array:
 			{
 				auto const &array_value = value.get_float32_array();
 				bz_assert(index_value < array_value.size());
-				return ast::constant_value_storage(array_value[index_value]);
+				return ast::constant_value(array_value[index_value]);
 			}
 			case ast::constant_value_kind::float64_array:
 			{
 				auto const &array_value = value.get_float64_array();
 				bz_assert(index_value < array_value.size());
-				return ast::constant_value_storage(array_value[index_value]);
+				return ast::constant_value(array_value[index_value]);
 			}
 			default:
 				bz_unreachable;
@@ -1440,7 +1440,7 @@ static ast::constant_value_storage evaluate_subscript(
 }
 
 template<typename Kind>
-static ast::constant_value_storage is_typespec_kind_helper(ast::expr_function_call &func_call)
+static ast::constant_value is_typespec_kind_helper(ast::expr_function_call &func_call)
 {
 	bz_assert(func_call.params.size() == 1);
 	bz_assert(func_call.params[0].is_constant());
@@ -1448,11 +1448,11 @@ static ast::constant_value_storage is_typespec_kind_helper(ast::expr_function_ca
 	auto const type = func_call.params[0]
 		.get_constant_value()
 		.get_type();
-	return ast::constant_value_storage(type.is<Kind>());
+	return ast::constant_value(type.is<Kind>());
 }
 
 template<typename Kind>
-static ast::constant_value_storage remove_typespec_kind_helper(ast::expr_function_call &func_call)
+static ast::constant_value remove_typespec_kind_helper(ast::expr_function_call &func_call, ctx::parse_context &context)
 {
 	bz_assert(func_call.params.size() == 1);
 	bz_assert(func_call.params[0].is_constant());
@@ -1462,15 +1462,15 @@ static ast::constant_value_storage remove_typespec_kind_helper(ast::expr_functio
 		.get_type();
 	if (type.is<Kind>())
 	{
-		return ast::constant_value_storage(type.get<Kind>());
+		return context.add_constant_type(type.get<Kind>());
 	}
 	else
 	{
-		return ast::constant_value_storage(type);
+		return context.add_constant_type(type);
 	}
 }
 
-static ast::constant_value_storage evaluate_intrinsic_function_call(
+static ast::constant_value evaluate_intrinsic_function_call(
 	ast::expression const &original_expr,
 	ast::expr_function_call &func_call,
 	ctx::parse_context &context
@@ -1491,7 +1491,7 @@ static ast::constant_value_storage evaluate_intrinsic_function_call(
 		auto const type = func_call.params[0].get_expr_type().remove_mut_reference();
 		bz_assert(type.is<ast::ts_array>());
 		bz_assert(type.get<ast::ts_array>().size != 0);
-		return ast::constant_value_storage(type.get<ast::ts_array>().size);
+		return ast::constant_value(type.get<ast::ts_array>().size);
 	}
 	case ast::function_body::builtin_enum_value:
 	{
@@ -1508,11 +1508,11 @@ static ast::constant_value_storage evaluate_intrinsic_function_call(
 		auto const is_signed = ast::is_signed_integer_kind(decl->underlying_type.get<ast::ts_base_type>().info->kind);
 		if (is_signed)
 		{
-			return ast::constant_value_storage(bit_cast<int64_t>(enum_value));
+			return ast::constant_value(bit_cast<int64_t>(enum_value));
 		}
 		else
 		{
-			return ast::constant_value_storage(enum_value);
+			return ast::constant_value(enum_value);
 		}
 	}
 	case ast::function_body::builtin_is_comptime:
@@ -1538,7 +1538,7 @@ static ast::constant_value_storage evaluate_intrinsic_function_call(
 				lhs += rhs;
 				return lhs;
 			});
-		return ast::constant_value_storage(std::move(result));
+		return context.add_constant_string(std::move(result));
 	}
 
 	case ast::function_body::typename_as_str:
@@ -1549,7 +1549,7 @@ static ast::constant_value_storage evaluate_intrinsic_function_call(
 		auto const type = func_call.params[0]
 			.get_constant_value()
 			.get_type();
-		return ast::constant_value_storage(bz::format("{}", type));
+		return context.add_constant_string(bz::format("{}", type));
 	}
 
 	case ast::function_body::is_mut:
@@ -1574,17 +1574,17 @@ static ast::constant_value_storage evaluate_intrinsic_function_call(
 		return is_typespec_kind_helper<ast::ts_enum>(func_call);
 
 	case ast::function_body::remove_mut:
-		return remove_typespec_kind_helper<ast::ts_mut>(func_call);
+		return remove_typespec_kind_helper<ast::ts_mut>(func_call, context);
 	case ast::function_body::remove_consteval:
-		return remove_typespec_kind_helper<ast::ts_consteval>(func_call);
+		return remove_typespec_kind_helper<ast::ts_consteval>(func_call, context);
 	case ast::function_body::remove_pointer:
-		return remove_typespec_kind_helper<ast::ts_pointer>(func_call);
+		return remove_typespec_kind_helper<ast::ts_pointer>(func_call, context);
 	case ast::function_body::remove_optional:
-		return remove_typespec_kind_helper<ast::ts_optional>(func_call);
+		return remove_typespec_kind_helper<ast::ts_optional>(func_call, context);
 	case ast::function_body::remove_reference:
-		return remove_typespec_kind_helper<ast::ts_lvalue_reference>(func_call);
+		return remove_typespec_kind_helper<ast::ts_lvalue_reference>(func_call, context);
 	case ast::function_body::remove_move_reference:
-		return remove_typespec_kind_helper<ast::ts_move_reference>(func_call);
+		return remove_typespec_kind_helper<ast::ts_move_reference>(func_call, context);
 	case ast::function_body::slice_value_type:
 	{
 		bz_assert(func_call.params.size() == 1);
@@ -1599,11 +1599,11 @@ static ast::constant_value_storage evaluate_intrinsic_function_call(
 				original_expr.src_tokens,
 				bz::format("'__builtin_slice_value_type' called on non-slice type '{}'", type)
 			);
-			return ast::constant_value_storage(type);
+			return context.add_constant_type(type);
 		}
 		else
 		{
-			return ast::constant_value_storage(type.get<ast::ts_array_slice>().elem_type);
+			return context.add_constant_type(type.get<ast::ts_array_slice>().elem_type);
 		}
 	}
 	case ast::function_body::array_value_type:
@@ -1620,11 +1620,11 @@ static ast::constant_value_storage evaluate_intrinsic_function_call(
 				original_expr.src_tokens,
 				bz::format("'__builtin_array_value_type' called on non-array type '{}'", type)
 			);
-			return ast::constant_value_storage(type);
+			return context.add_constant_type(type);
 		}
 		else
 		{
-			return ast::constant_value_storage(type.get<ast::ts_array>().elem_type);
+			return context.add_constant_type(type.get<ast::ts_array>().elem_type);
 		}
 	}
 	case ast::function_body::tuple_value_type:
@@ -1646,7 +1646,7 @@ static ast::constant_value_storage evaluate_intrinsic_function_call(
 				original_expr.src_tokens,
 				bz::format("'__builtin_tuple_value_type' called on non-tuple type '{}'", type)
 			);
-			return ast::constant_value_storage(type);
+			return context.add_constant_type(type);
 		}
 		else if (index >= type.get<ast::ts_tuple>().types.size())
 		{
@@ -1654,11 +1654,18 @@ static ast::constant_value_storage evaluate_intrinsic_function_call(
 				original_expr.src_tokens,
 				bz::format("index {} is out of range in '__builtin_tuple_value_type' with tuple type '{}'", index, type)
 			);
-			return ast::constant_value_storage(type.get<ast::ts_tuple>().types.back());
+			if (type.get<ast::ts_tuple>().types.empty())
+			{
+				return context.add_constant_type(ast::make_void_typespec(nullptr));
+			}
+			else
+			{
+				return context.add_constant_type(type.get<ast::ts_tuple>().types.back());
+			}
 		}
 		else
 		{
-			return ast::constant_value_storage(type.get<ast::ts_tuple>().types[index]);
+			return context.add_constant_type(type.get<ast::ts_tuple>().types[index]);
 		}
 	}
 	case ast::function_body::concat_tuple_types:
@@ -1690,13 +1697,11 @@ static ast::constant_value_storage evaluate_intrinsic_function_call(
 					bz::format("'__builtin_concat_tuple_types' called with non-tuple type '{}' as rhs", rhs_type)
 				);
 			}
-			return ast::constant_value_storage(lhs_type);
+			return context.add_constant_type(lhs_type);
 		}
 		else
 		{
-			auto result = ast::constant_value_storage();
-			auto &result_type = result.emplace<ast::constant_value_kind::type>();
-			result_type = ast::make_tuple_typespec(original_expr.src_tokens, {});
+			auto result_type = ast::make_tuple_typespec(original_expr.src_tokens, {});
 			auto const &lhs_tuple_types = lhs_type.get<ast::ts_tuple>().types;
 			auto const &rhs_tuple_types = rhs_type.get<ast::ts_tuple>().types;
 
@@ -1705,7 +1710,7 @@ static ast::constant_value_storage evaluate_intrinsic_function_call(
 			result_tuple_types.append(lhs_tuple_types);
 			result_tuple_types.append(rhs_tuple_types);
 
-			return result;
+			return context.add_constant_type(std::move(result_type));
 		}
 	}
 	case ast::function_body::enum_underlying_type:
@@ -1722,12 +1727,12 @@ static ast::constant_value_storage evaluate_intrinsic_function_call(
 				original_expr.src_tokens,
 				bz::format("'__builtin_enum_underlying_type' called on non-enum type '{}'", type)
 			);
-			return ast::constant_value_storage(type);
+			return context.add_constant_type(type);
 		}
 		else
 		{
 			context.resolve_type(original_expr.src_tokens, type.get<ast::ts_enum>().decl);
-			return ast::constant_value_storage(type.get<ast::ts_enum>().decl->underlying_type);
+			return context.add_constant_type(type.get<ast::ts_enum>().decl->underlying_type);
 		}
 	}
 
@@ -1739,7 +1744,7 @@ static ast::constant_value_storage evaluate_intrinsic_function_call(
 		auto const type = func_call.params[0]
 			.get_constant_value()
 			.get_type();
-		return ast::constant_value_storage(context.is_default_constructible(original_expr.src_tokens, type));
+		return ast::constant_value(context.is_default_constructible(original_expr.src_tokens, type));
 	}
 	case ast::function_body::is_copy_constructible:
 	{
@@ -1749,7 +1754,7 @@ static ast::constant_value_storage evaluate_intrinsic_function_call(
 		auto const type = func_call.params[0]
 			.get_constant_value()
 			.get_type();
-		return ast::constant_value_storage(context.is_copy_constructible(original_expr.src_tokens, type));
+		return ast::constant_value(context.is_copy_constructible(original_expr.src_tokens, type));
 	}
 	case ast::function_body::is_trivially_copy_constructible:
 	{
@@ -1759,7 +1764,7 @@ static ast::constant_value_storage evaluate_intrinsic_function_call(
 		auto const type = func_call.params[0]
 			.get_constant_value()
 			.get_type();
-		return ast::constant_value_storage(context.is_trivially_copy_constructible(original_expr.src_tokens, type));
+		return ast::constant_value(context.is_trivially_copy_constructible(original_expr.src_tokens, type));
 	}
 	case ast::function_body::is_move_constructible:
 	{
@@ -1769,7 +1774,7 @@ static ast::constant_value_storage evaluate_intrinsic_function_call(
 		auto const type = func_call.params[0]
 			.get_constant_value()
 			.get_type();
-		return ast::constant_value_storage(context.is_move_constructible(original_expr.src_tokens, type));
+		return ast::constant_value(context.is_move_constructible(original_expr.src_tokens, type));
 	}
 	case ast::function_body::is_trivially_move_constructible:
 	{
@@ -1779,7 +1784,7 @@ static ast::constant_value_storage evaluate_intrinsic_function_call(
 		auto const type = func_call.params[0]
 			.get_constant_value()
 			.get_type();
-		return ast::constant_value_storage(context.is_trivially_move_constructible(original_expr.src_tokens, type));
+		return ast::constant_value(context.is_trivially_move_constructible(original_expr.src_tokens, type));
 	}
 	case ast::function_body::is_trivially_destructible:
 	{
@@ -1789,7 +1794,7 @@ static ast::constant_value_storage evaluate_intrinsic_function_call(
 		auto const type = func_call.params[0]
 			.get_constant_value()
 			.get_type();
-		return ast::constant_value_storage(context.is_trivially_destructible(original_expr.src_tokens, type));
+		return ast::constant_value(context.is_trivially_destructible(original_expr.src_tokens, type));
 	}
 	case ast::function_body::is_trivially_move_destructible:
 	{
@@ -1799,7 +1804,7 @@ static ast::constant_value_storage evaluate_intrinsic_function_call(
 		auto const type = func_call.params[0]
 			.get_constant_value()
 			.get_type();
-		return ast::constant_value_storage(context.is_trivially_move_destructible(original_expr.src_tokens, type));
+		return ast::constant_value(context.is_trivially_move_destructible(original_expr.src_tokens, type));
 	}
 	case ast::function_body::is_trivially_relocatable:
 	{
@@ -1809,7 +1814,7 @@ static ast::constant_value_storage evaluate_intrinsic_function_call(
 		auto const type = func_call.params[0]
 			.get_constant_value()
 			.get_type();
-		return ast::constant_value_storage(context.is_trivially_relocatable(original_expr.src_tokens, type));
+		return ast::constant_value(context.is_trivially_relocatable(original_expr.src_tokens, type));
 	}
 	case ast::function_body::is_trivial:
 	{
@@ -1819,31 +1824,31 @@ static ast::constant_value_storage evaluate_intrinsic_function_call(
 		auto const type = func_call.params[0]
 			.get_constant_value()
 			.get_type();
-		return ast::constant_value_storage(context.is_trivial(original_expr.src_tokens, type));
+		return ast::constant_value(context.is_trivial(original_expr.src_tokens, type));
 	}
 
 	case ast::function_body::i8_default_constructor:
 	case ast::function_body::i16_default_constructor:
 	case ast::function_body::i32_default_constructor:
 	case ast::function_body::i64_default_constructor:
-		return ast::constant_value_storage(int64_t());
+		return ast::constant_value(int64_t());
 	case ast::function_body::u8_default_constructor:
 	case ast::function_body::u16_default_constructor:
 	case ast::function_body::u32_default_constructor:
 	case ast::function_body::u64_default_constructor:
-		return ast::constant_value_storage(uint64_t());
+		return ast::constant_value(uint64_t());
 	case ast::function_body::f32_default_constructor:
-		return ast::constant_value_storage(float32_t());
+		return ast::constant_value(float32_t());
 	case ast::function_body::f64_default_constructor:
-		return ast::constant_value_storage(float64_t());
+		return ast::constant_value(float64_t());
 	case ast::function_body::char_default_constructor:
-		return ast::constant_value_storage(bz::u8char());
+		return ast::constant_value(bz::u8char());
 	case ast::function_body::str_default_constructor:
-		return ast::constant_value_storage(bz::u8string());
+		return ast::constant_value(bz::u8string_view());
 	case ast::function_body::bool_default_constructor:
-		return ast::constant_value_storage(bool());
+		return ast::constant_value(bool());
 	case ast::function_body::null_t_default_constructor:
-		return ast::constant_value_storage::get_null();
+		return ast::constant_value::get_null();
 
 	case ast::function_body::builtin_unary_plus:
 	{
@@ -1872,7 +1877,7 @@ static ast::constant_value_storage evaluate_intrinsic_function_call(
 			bz_assert(const_expr.type.remove_any_mut().is<ast::ts_base_type>());
 			auto const type = const_expr.type.remove_any_mut().get<ast::ts_base_type>().info->kind;
 			auto const int_val = value.get_sint();
-			return ast::constant_value_storage(safe_unary_minus(
+			return ast::constant_value(safe_unary_minus(
 				original_expr.src_tokens, original_expr.paren_level,
 				int_val, type, context
 			));
@@ -1880,13 +1885,13 @@ static ast::constant_value_storage evaluate_intrinsic_function_call(
 		else if (value.is_float32())
 		{
 			auto const float_val = value.get_float32();
-			return ast::constant_value_storage(-float_val);
+			return ast::constant_value(-float_val);
 		}
 		else
 		{
 			bz_assert(value.is_float64());
 			auto const float_val = value.get_float64();
-			return ast::constant_value_storage(-float_val);
+			return ast::constant_value(-float_val);
 		}
 	}
 	case ast::function_body::builtin_unary_dereference:
@@ -1903,7 +1908,7 @@ static ast::constant_value_storage evaluate_intrinsic_function_call(
 		if (value.is_boolean())
 		{
 			auto const bool_val = value.get_boolean();
-			return ast::constant_value_storage(!bool_val);
+			return ast::constant_value(!bool_val);
 		}
 		else
 		{
@@ -1915,13 +1920,13 @@ static ast::constant_value_storage evaluate_intrinsic_function_call(
 			switch (param_kind)
 			{
 			case ast::type_info::uint8_:
-				return ast::constant_value_storage(uint64_t(uint8_t(~uint_val)));
+				return ast::constant_value(uint64_t(uint8_t(~uint_val)));
 			case ast::type_info::uint16_:
-				return ast::constant_value_storage(uint64_t(uint16_t(~uint_val)));
+				return ast::constant_value(uint64_t(uint16_t(~uint_val)));
 			case ast::type_info::uint32_:
-				return ast::constant_value_storage(uint64_t(uint32_t(~uint_val)));
+				return ast::constant_value(uint64_t(uint32_t(~uint_val)));
 			case ast::type_info::uint64_:
-				return ast::constant_value_storage(~uint_val);
+				return ast::constant_value(~uint_val);
 			default:
 				bz_unreachable;
 			}
@@ -1937,7 +1942,7 @@ static ast::constant_value_storage evaluate_intrinsic_function_call(
 		bz_assert(func_call.params[0].is_constant());
 		bz_assert(func_call.params[0].get_constant_value().is_boolean());
 		auto const bool_val = func_call.params[0].get_constant_value().get_boolean();
-		return ast::constant_value_storage(!bool_val);
+		return ast::constant_value(!bool_val);
 	}
 	case ast::function_body::builtin_unary_plus_plus:
 	case ast::function_body::builtin_unary_minus_minus:
@@ -1988,7 +1993,7 @@ static ast::constant_value_storage evaluate_intrinsic_function_call(
 	}
 }
 
-static ast::constant_value_storage get_default_constructed_value(
+static ast::constant_value get_default_constructed_value(
 	lex::src_tokens const &src_tokens,
 	ast::typespec_view type,
 	ctx::parse_context &context
@@ -2003,12 +2008,11 @@ static ast::constant_value_storage get_default_constructed_value(
 	if (type.modifiers.not_empty())
 	{
 		bz_assert(type.is<ast::ts_optional>());
-		return ast::constant_value_storage::get_null();
+		return ast::constant_value::get_null();
 	}
 	else if (type.is<ast::ts_array>())
 	{
 		auto const [elem_type, size, is_multi_dimensional] = get_flattened_array_type_and_size(type);
-		ast::constant_value_storage result;
 		auto const elem_builtin_kind = elem_type.is<ast::ts_base_type>()
 			? elem_type.get<ast::ts_base_type>().info->kind
 			: ast::type_info::aggregate;
@@ -2018,36 +2022,34 @@ static ast::constant_value_storage get_default_constructed_value(
 		case ast::type_info::int16_:
 		case ast::type_info::int32_:
 		case ast::type_info::int64_:
-			result.emplace<ast::constant_value_kind::sint_array>(size, 0);
-			break;
+			return context.add_constant_sint_array(ast::arena_vector<int64_t>(size, 0));
 		case ast::type_info::uint8_:
 		case ast::type_info::uint16_:
 		case ast::type_info::uint32_:
 		case ast::type_info::uint64_:
-			result.emplace<ast::constant_value_kind::uint_array>(size, 0);
-			break;
+			return context.add_constant_uint_array(ast::arena_vector<uint64_t>(size, 0));
 		case ast::type_info::float32_:
-			result.emplace<ast::constant_value_kind::float32_array>(size, 0.0f);
-			break;
+			return context.add_constant_float32_array(ast::arena_vector<float32_t>(size, 0.0f));
 		case ast::type_info::float64_:
-			result.emplace<ast::constant_value_kind::float64_array>(size, 0.0);
-			break;
+			return context.add_constant_float64_array(ast::arena_vector<float64_t>(size, 0.0));
 		default:
 		{
 			auto const elem_value = get_default_constructed_value(src_tokens, elem_type, context);
 			if (elem_value.not_null())
 			{
-				result.emplace<ast::constant_value_kind::array>(size, elem_value);
+				return context.add_constant_array(ast::arena_vector<ast::constant_value>(size, elem_value));
 			}
-			break;
+			else
+			{
+				return ast::constant_value();
+			}
 		}
 		}
-		return result;
 	}
 	else
 	{
 		return type.terminator->visit(bz::overload{
-			[&src_tokens, &context](ast::ts_base_type const &base_t) -> ast::constant_value_storage {
+			[&src_tokens, &context](ast::ts_base_type const &base_t) -> ast::constant_value {
 				if (base_t.info->kind != ast::type_info::aggregate)
 				{
 					switch (base_t.info->kind)
@@ -2056,24 +2058,24 @@ static ast::constant_value_storage get_default_constructed_value(
 					case ast::type_info::int16_:
 					case ast::type_info::int32_:
 					case ast::type_info::int64_:
-						return ast::constant_value_storage(int64_t());
+						return ast::constant_value(int64_t());
 					case ast::type_info::uint8_:
 					case ast::type_info::uint16_:
 					case ast::type_info::uint32_:
 					case ast::type_info::uint64_:
-						return ast::constant_value_storage(uint64_t());
+						return ast::constant_value(uint64_t());
 					case ast::type_info::float32_:
-						return ast::constant_value_storage(float32_t());
+						return ast::constant_value(float32_t());
 					case ast::type_info::float64_:
-						return ast::constant_value_storage(float64_t());
+						return ast::constant_value(float64_t());
 					case ast::type_info::char_:
-						return ast::constant_value_storage(bz::u8char());
+						return ast::constant_value(bz::u8char());
 					case ast::type_info::str_:
-						return ast::constant_value_storage(bz::u8string());
+						return ast::constant_value(bz::u8string_view());
 					case ast::type_info::bool_:
-						return ast::constant_value_storage(bool());
+						return ast::constant_value(bool());
 					case ast::type_info::null_t_:
-						return ast::constant_value_storage::get_null();
+						return ast::constant_value::get_null();
 
 					default:
 						bz_unreachable;
@@ -2081,51 +2083,47 @@ static ast::constant_value_storage get_default_constructed_value(
 				}
 				else if (base_t.info->kind == ast::type_info::aggregate && base_t.info->default_constructor == nullptr)
 				{
-					ast::constant_value_storage result;
-					auto &elems = result.emplace<ast::constant_value_kind::aggregate>();
+					auto elems = ast::arena_vector<ast::constant_value>();
 					elems.reserve(base_t.info->member_variables.size());
 					for (auto const member : base_t.info->member_variables)
 					{
 						elems.push_back(get_default_constructed_value(src_tokens, member->get_type(), context));
 						if (elems.back().is_null())
 						{
-							result.clear();
-							return result;
+							return ast::constant_value();
 						}
 					}
-					return result;
+					return context.add_constant_aggregate(std::move(elems));
 				}
 				else
 				{
-					return {};
+					return ast::constant_value();
 				}
 			},
-			[](ast::ts_array_slice const &) -> ast::constant_value_storage {
-				return {};
+			[](ast::ts_array_slice const &) -> ast::constant_value {
+				return ast::constant_value();
 			},
-			[&src_tokens, &context](ast::ts_tuple const &tuple_t) -> ast::constant_value_storage {
-				ast::constant_value_storage result;
-				auto &elems = result.emplace<ast::constant_value_kind::tuple>();
+			[&src_tokens, &context](ast::ts_tuple const &tuple_t) -> ast::constant_value {
+				auto elems = ast::arena_vector<ast::constant_value>();
 				elems.reserve(tuple_t.types.size());
 				for (auto const &type : tuple_t.types)
 				{
 					elems.push_back(get_default_constructed_value(src_tokens, type, context));
 					if (elems.back().is_null())
 					{
-						result.clear();
-						return result;
+						return ast::constant_value();
 					}
 				}
-				return result;
+				return context.add_constant_tuple(std::move(elems));
 			},
-			[](auto const &) -> ast::constant_value_storage {
+			[](auto const &) -> ast::constant_value {
 				bz_unreachable;
 			}
 		});
 	}
 }
 
-static ast::constant_value_storage consteval_guaranteed_function_call(
+static ast::constant_value consteval_guaranteed_function_call(
 	ast::expression const &original_expr,
 	ast::expr_function_call &func_call,
 	ctx::parse_context &context
@@ -2150,7 +2148,7 @@ static ast::constant_value_storage consteval_guaranteed_function_call(
 	}
 }
 
-static ast::constant_value_storage evaluate_cast(
+static ast::constant_value evaluate_cast(
 	ast::expression const &original_expr,
 	ast::expr_cast const &subscript_expr,
 	ctx::parse_context &context
@@ -2177,7 +2175,7 @@ static ast::constant_value_storage evaluate_cast(
 	{
 		switch (value.kind())
 		{
-		static_assert(ast::constant_value_storage::variant_count == 19);
+		static_assert(ast::constant_value::variant_count == 19);
 		case ast::constant_value_kind::sint:
 		{
 			using T = std::tuple<bz::u8string_view, int64_t, int64_t, int64_t>;
@@ -2195,7 +2193,7 @@ static ast::constant_value_storage evaluate_cast(
 					bz::format("overflow in constant expression '{} as {}' results in {}", int_val, type_name, result)
 				);
 			}
-			return ast::constant_value_storage(result);
+			return ast::constant_value(result);
 		}
 		case ast::constant_value_kind::uint:
 		{
@@ -2214,7 +2212,7 @@ static ast::constant_value_storage evaluate_cast(
 					bz::format("overflow in constant expression '{} as {}' results in {}", int_val, type_name, result)
 				);
 			}
-			return ast::constant_value_storage(result);
+			return ast::constant_value(result);
 		}
 		case ast::constant_value_kind::float32:
 		{
@@ -2224,7 +2222,7 @@ static ast::constant_value_storage evaluate_cast(
 				dest_kind == ast::type_info::int16_ ? static_cast<int16_t>(float_val) :
 				dest_kind == ast::type_info::int32_ ? static_cast<int32_t>(float_val) :
 				static_cast<int64_t>(float_val);
-			return ast::constant_value_storage(result);
+			return ast::constant_value(result);
 		}
 		case ast::constant_value_kind::float64:
 		{
@@ -2234,13 +2232,13 @@ static ast::constant_value_storage evaluate_cast(
 				dest_kind == ast::type_info::int16_ ? static_cast<int16_t>(float_val) :
 				dest_kind == ast::type_info::int32_ ? static_cast<int32_t>(float_val) :
 				static_cast<int64_t>(float_val);
-			return ast::constant_value_storage(result);
+			return ast::constant_value(result);
 		}
 		case ast::constant_value_kind::u8char:
 			// no overflow possible in constant expressions
-			return ast::constant_value_storage(static_cast<int64_t>(value.get_u8char()));
+			return ast::constant_value(static_cast<int64_t>(value.get_u8char()));
 		case ast::constant_value_kind::boolean:
-			return ast::constant_value_storage(static_cast<int64_t>(value.get_boolean()));
+			return ast::constant_value(static_cast<int64_t>(value.get_boolean()));
 		default:
 			bz_unreachable;
 		}
@@ -2253,7 +2251,7 @@ static ast::constant_value_storage evaluate_cast(
 	{
 		switch (value.kind())
 		{
-		static_assert(ast::constant_value_storage::variant_count == 19);
+		static_assert(ast::constant_value::variant_count == 19);
 		case ast::constant_value_kind::sint:
 		{
 			using T = std::tuple<bz::u8string_view, uint64_t, uint64_t>;
@@ -2271,7 +2269,7 @@ static ast::constant_value_storage evaluate_cast(
 					bz::format("overflow in constant expression '{} as {}' results in {}", int_val, type_name, result)
 				);
 			}
-			return ast::constant_value_storage(result);
+			return ast::constant_value(result);
 		}
 		case ast::constant_value_kind::uint:
 		{
@@ -2290,7 +2288,7 @@ static ast::constant_value_storage evaluate_cast(
 					bz::format("overflow in constant expression '{} as {}' results in {}", int_val, type_name, result)
 				);
 			}
-			return ast::constant_value_storage(result);
+			return ast::constant_value(result);
 		}
 		case ast::constant_value_kind::float32:
 		{
@@ -2300,7 +2298,7 @@ static ast::constant_value_storage evaluate_cast(
 				dest_kind == ast::type_info::uint16_ ? static_cast<uint16_t>(float_val) :
 				dest_kind == ast::type_info::uint32_ ? static_cast<uint32_t>(float_val) :
 				static_cast<uint64_t>(float_val);
-			return ast::constant_value_storage(result);
+			return ast::constant_value(result);
 		}
 		case ast::constant_value_kind::float64:
 		{
@@ -2310,13 +2308,13 @@ static ast::constant_value_storage evaluate_cast(
 				dest_kind == ast::type_info::uint16_ ? static_cast<uint16_t>(float_val) :
 				dest_kind == ast::type_info::uint32_ ? static_cast<uint32_t>(float_val) :
 				static_cast<uint64_t>(float_val);
-			return ast::constant_value_storage(result);
+			return ast::constant_value(result);
 		}
 		case ast::constant_value_kind::u8char:
 			// no overflow possible in constant expressions
-			return ast::constant_value_storage(static_cast<uint64_t>(value.get_u8char()));
+			return ast::constant_value(static_cast<uint64_t>(value.get_u8char()));
 		case ast::constant_value_kind::boolean:
-			return ast::constant_value_storage(static_cast<uint64_t>(value.get_boolean()));
+			return ast::constant_value(static_cast<uint64_t>(value.get_boolean()));
 		default:
 			bz_unreachable;
 		}
@@ -2325,37 +2323,37 @@ static ast::constant_value_storage evaluate_cast(
 	case ast::type_info::float32_:
 		switch (value.kind())
 		{
-		static_assert(ast::constant_value_storage::variant_count == 19);
+		static_assert(ast::constant_value::variant_count == 19);
 		case ast::constant_value_kind::sint:
-			return ast::constant_value_storage(static_cast<float32_t>(value.get_sint()));
+			return ast::constant_value(static_cast<float32_t>(value.get_sint()));
 		case ast::constant_value_kind::uint:
-			return ast::constant_value_storage(static_cast<float32_t>(value.get_uint()));
+			return ast::constant_value(static_cast<float32_t>(value.get_uint()));
 		case ast::constant_value_kind::float32:
-			return ast::constant_value_storage(static_cast<float32_t>(value.get_float32()));
+			return ast::constant_value(static_cast<float32_t>(value.get_float32()));
 		case ast::constant_value_kind::float64:
-			return ast::constant_value_storage(static_cast<float32_t>(value.get_float64()));
+			return ast::constant_value(static_cast<float32_t>(value.get_float64()));
 		default:
 			bz_unreachable;
 		}
 	case ast::type_info::float64_:
 		switch (value.kind())
 		{
-		static_assert(ast::constant_value_storage::variant_count == 19);
+		static_assert(ast::constant_value::variant_count == 19);
 		case ast::constant_value_kind::sint:
-			return ast::constant_value_storage(static_cast<float64_t>(value.get_sint()));
+			return ast::constant_value(static_cast<float64_t>(value.get_sint()));
 		case ast::constant_value_kind::uint:
-			return ast::constant_value_storage(static_cast<float64_t>(value.get_uint()));
+			return ast::constant_value(static_cast<float64_t>(value.get_uint()));
 		case ast::constant_value_kind::float32:
-			return ast::constant_value_storage(static_cast<float64_t>(value.get_float32()));
+			return ast::constant_value(static_cast<float64_t>(value.get_float32()));
 		case ast::constant_value_kind::float64:
-			return ast::constant_value_storage(static_cast<float64_t>(value.get_float64()));
+			return ast::constant_value(static_cast<float64_t>(value.get_float64()));
 		default:
 			bz_unreachable;
 		}
 	case ast::type_info::char_:
 		switch (value.kind())
 		{
-		static_assert(ast::constant_value_storage::variant_count == 19);
+		static_assert(ast::constant_value::variant_count == 19);
 		case ast::constant_value_kind::sint:
 		{
 			auto const result = static_cast<bz::u8char>(value.get_sint());
@@ -2371,7 +2369,7 @@ static ast::constant_value_storage evaluate_cast(
 				}
 				return {};
 			}
-			return ast::constant_value_storage(result);
+			return ast::constant_value(result);
 		}
 		case ast::constant_value_kind::uint:
 		{
@@ -2388,7 +2386,7 @@ static ast::constant_value_storage evaluate_cast(
 				}
 				return {};
 			}
-			return ast::constant_value_storage(result);
+			return ast::constant_value(result);
 		}
 		default:
 			bz_unreachable;
@@ -2469,7 +2467,7 @@ static bool consteval_guaranteed_special_array_value_helper(
 	return true;
 }
 
-static ast::constant_value_storage consteval_guaranteed_special_array_value(
+static ast::constant_value consteval_guaranteed_special_array_value(
 	ast::typespec_view array_type,
 	bz::array_view<ast::expression> exprs,
 	ctx::parse_context &context
@@ -2486,8 +2484,7 @@ static ast::constant_value_storage consteval_guaranteed_special_array_value(
 	case ast::type_info::int32_:
 	case ast::type_info::int64_:
 	{
-		auto result = ast::constant_value_storage();
-		auto &sint_array = result.emplace<ast::constant_value_kind::sint_array>();
+		auto sint_array = ast::arena_vector<int64_t>();
 		sint_array.reserve(size);
 
 		auto const good = consteval_guaranteed_special_array_value_helper<
@@ -2500,19 +2497,21 @@ static ast::constant_value_storage consteval_guaranteed_special_array_value(
 			context
 		);
 
-		if (!good)
+		if (good)
 		{
-			result.clear();
+			return context.add_constant_sint_array(std::move(sint_array));
 		}
-		return result;
+		else
+		{
+			return ast::constant_value();
+		}
 	}
 	case ast::type_info::uint8_:
 	case ast::type_info::uint16_:
 	case ast::type_info::uint32_:
 	case ast::type_info::uint64_:
 	{
-		auto result = ast::constant_value_storage();
-		auto &uint_array = result.emplace<ast::constant_value_kind::uint_array>();
+		auto uint_array = ast::arena_vector<uint64_t>();
 		uint_array.reserve(size);
 
 		auto const good = consteval_guaranteed_special_array_value_helper<
@@ -2525,16 +2524,18 @@ static ast::constant_value_storage consteval_guaranteed_special_array_value(
 			context
 		);
 
-		if (!good)
+		if (good)
 		{
-			result.clear();
+			return context.add_constant_uint_array(std::move(uint_array));
 		}
-		return result;
+		else
+		{
+			return ast::constant_value();
+		}
 	}
 	case ast::type_info::float32_:
 	{
-		auto result = ast::constant_value_storage();
-		auto &float32_array = result.emplace<ast::constant_value_kind::float32_array>();
+		auto float32_array = ast::arena_vector<float32_t>();
 		float32_array.reserve(size);
 
 		auto const good = consteval_guaranteed_special_array_value_helper<
@@ -2547,16 +2548,18 @@ static ast::constant_value_storage consteval_guaranteed_special_array_value(
 			context
 		);
 
-		if (!good)
+		if (good)
 		{
-			result.clear();
+			return context.add_constant_float32_array(std::move(float32_array));
 		}
-		return result;
+		else
+		{
+			return ast::constant_value();
+		}
 	}
 	case ast::type_info::float64_:
 	{
-		auto result = ast::constant_value_storage();
-		auto &float64_array = result.emplace<ast::constant_value_kind::float64_array>();
+		auto float64_array = ast::arena_vector<float64_t>();
 		float64_array.reserve(size);
 
 		auto const good = consteval_guaranteed_special_array_value_helper<
@@ -2569,18 +2572,25 @@ static ast::constant_value_storage consteval_guaranteed_special_array_value(
 			context
 		);
 
-		if (!good)
+		if (good)
 		{
-			result.clear();
+			return context.add_constant_float64_array(std::move(float64_array));
 		}
-		return result;
+		else
+		{
+			return ast::constant_value();
+		}
 	}
 	default:
 		bz_unreachable;
 	}
 }
 
-static ast::constant_value_storage get_special_array_value(ast::typespec_view array_type, bz::array_view<ast::expression const> exprs)
+static ast::constant_value get_special_array_value(
+	ast::typespec_view array_type,
+	bz::array_view<ast::expression const> exprs,
+	ctx::parse_context &context
+)
 {
 	auto const [elem_type, size, is_multi_dimensional] = get_flattened_array_type_and_size(array_type);
 	bz_assert(elem_type.is<ast::ts_base_type>());
@@ -2593,8 +2603,7 @@ static ast::constant_value_storage get_special_array_value(ast::typespec_view ar
 	case ast::type_info::int32_:
 	case ast::type_info::int64_:
 	{
-		auto result = ast::constant_value_storage();
-		auto &sint_array = result.emplace<ast::constant_value_kind::sint_array>();
+		auto sint_array = ast::arena_vector<int64_t>();
 		sint_array.reserve(size);
 		if (is_multi_dimensional)
 		{
@@ -2610,15 +2619,14 @@ static ast::constant_value_storage get_special_array_value(ast::typespec_view ar
 				sint_array.push_back(expr.get_constant_value().get_sint());
 			}
 		}
-		return result;
+		return context.add_constant_sint_array(std::move(sint_array));
 	}
 	case ast::type_info::uint8_:
 	case ast::type_info::uint16_:
 	case ast::type_info::uint32_:
 	case ast::type_info::uint64_:
 	{
-		auto result = ast::constant_value_storage();
-		auto &uint_array = result.emplace<ast::constant_value_kind::uint_array>();
+		auto uint_array = ast::arena_vector<uint64_t>();
 		uint_array.reserve(size);
 		if (is_multi_dimensional)
 		{
@@ -2634,12 +2642,11 @@ static ast::constant_value_storage get_special_array_value(ast::typespec_view ar
 				uint_array.push_back(expr.get_constant_value().get_uint());
 			}
 		}
-		return result;
+		return context.add_constant_uint_array(std::move(uint_array));
 	}
 	case ast::type_info::float32_:
 	{
-		auto result = ast::constant_value_storage();
-		auto &float32_array = result.emplace<ast::constant_value_kind::float32_array>();
+		auto float32_array = ast::arena_vector<float32_t>();
 		float32_array.reserve(size);
 		if (is_multi_dimensional)
 		{
@@ -2655,12 +2662,11 @@ static ast::constant_value_storage get_special_array_value(ast::typespec_view ar
 				float32_array.push_back(expr.get_constant_value().get_float32());
 			}
 		}
-		return result;
+		return context.add_constant_float32_array(std::move(float32_array));
 	}
 	case ast::type_info::float64_:
 	{
-		auto result = ast::constant_value_storage();
-		auto &float64_array = result.emplace<ast::constant_value_kind::float64_array>();
+		auto float64_array = ast::arena_vector<float64_t>();
 		float64_array.reserve(size);
 		if (is_multi_dimensional)
 		{
@@ -2676,84 +2682,84 @@ static ast::constant_value_storage get_special_array_value(ast::typespec_view ar
 				float64_array.push_back(expr.get_constant_value().get_float64());
 			}
 		}
-		return result;
+		return context.add_constant_float64_array(std::move(float64_array));
 	}
 	default:
 		bz_unreachable;
 	}
 }
 
-static ast::constant_value_storage guaranteed_evaluate_expr(
+static ast::constant_value guaranteed_evaluate_expr(
 	ast::expression &expr,
 	ctx::parse_context &context
 )
 {
 	return expr.get_expr().visit(bz::overload{
-		[](ast::expr_variable_name &) -> ast::constant_value_storage {
+		[](ast::expr_variable_name &) -> ast::constant_value {
 			// identifiers are only constant expressions if they are a consteval
 			// variable, which is handled in parse_context::make_identifier_expr (or something similar)
 			return {};
 		},
-		[](ast::expr_function_name &) -> ast::constant_value_storage {
+		[](ast::expr_function_name &) -> ast::constant_value {
 			// these are always constant expressions
 			bz_unreachable;
 		},
-		[](ast::expr_function_alias_name &) -> ast::constant_value_storage {
+		[](ast::expr_function_alias_name &) -> ast::constant_value {
 			// these are always constant expressions
 			bz_unreachable;
 		},
-		[](ast::expr_function_overload_set &) -> ast::constant_value_storage {
+		[](ast::expr_function_overload_set &) -> ast::constant_value {
 			// these are always constant expressions
 			bz_unreachable;
 		},
-		[](ast::expr_struct_name &) -> ast::constant_value_storage {
+		[](ast::expr_struct_name &) -> ast::constant_value {
 			// these are always constant expressions
 			bz_unreachable;
 		},
-		[](ast::expr_enum_name &) -> ast::constant_value_storage {
+		[](ast::expr_enum_name &) -> ast::constant_value {
 			// these are always constant expressions
 			bz_unreachable;
 		},
-		[](ast::expr_type_alias_name &) -> ast::constant_value_storage {
+		[](ast::expr_type_alias_name &) -> ast::constant_value {
 			// these are always constant expressions
 			bz_unreachable;
 		},
-		[](ast::expr_integer_literal &) -> ast::constant_value_storage {
+		[](ast::expr_integer_literal &) -> ast::constant_value {
 			// these are always constant expressions
 			bz_unreachable;
 		},
-		[](ast::expr_null_literal &) -> ast::constant_value_storage {
+		[](ast::expr_null_literal &) -> ast::constant_value {
 			// these are always constant expressions
 			bz_unreachable;
 		},
-		[](ast::expr_enum_literal &) -> ast::constant_value_storage {
+		[](ast::expr_enum_literal &) -> ast::constant_value {
 			// these are always constant expressions
 			bz_unreachable;
 		},
-		[](ast::expr_typed_literal &) -> ast::constant_value_storage {
+		[](ast::expr_typed_literal &) -> ast::constant_value {
 			// these are always constant expressions
 			bz_unreachable;
 		},
-		[](ast::expr_placeholder_literal &) -> ast::constant_value_storage {
+		[](ast::expr_placeholder_literal &) -> ast::constant_value {
 			return {};
 		},
-		[](ast::expr_typename_literal &) -> ast::constant_value_storage {
+		[](ast::expr_typename_literal &) -> ast::constant_value {
 			// these are always constant expressions
 			bz_unreachable;
 		},
-		[&context](ast::expr_tuple &tuple) -> ast::constant_value_storage {
+		[&context](ast::expr_tuple &tuple) -> ast::constant_value {
 			for (auto &elem : tuple.elems)
 			{
 				consteval_guaranteed(elem, context);
 			}
 			return {};
 		},
-		[&context](ast::expr_unary_op &unary_op) -> ast::constant_value_storage {
+		[&context](ast::expr_unary_op &unary_op) -> ast::constant_value {
 			// builtin operators are handled as intrinsic functions
 			consteval_guaranteed(unary_op.expr, context);
 			return {};
 		},
-		[&expr, &context](ast::expr_binary_op &binary_op) -> ast::constant_value_storage {
+		[&expr, &context](ast::expr_binary_op &binary_op) -> ast::constant_value {
 			consteval_guaranteed(binary_op.lhs, context);
 			consteval_guaranteed(binary_op.rhs, context);
 
@@ -2769,7 +2775,7 @@ static ast::constant_value_storage guaranteed_evaluate_expr(
 					auto const lhs_bool_val = lhs_value.get_boolean();
 					if (!lhs_bool_val)
 					{
-						return ast::constant_value_storage(false);
+						return ast::constant_value(false);
 					}
 				}
 				else if (op == lex::token::bool_or)
@@ -2780,7 +2786,7 @@ static ast::constant_value_storage guaranteed_evaluate_expr(
 					auto const lhs_bool_val = lhs_value.get_boolean();
 					if (lhs_bool_val)
 					{
-						return ast::constant_value_storage(true);
+						return ast::constant_value(true);
 					}
 				}
 			}
@@ -2794,7 +2800,7 @@ static ast::constant_value_storage guaranteed_evaluate_expr(
 				return {};
 			}
 		},
-		[&context](ast::expr_tuple_subscript &tuple_subscript_expr) -> ast::constant_value_storage {
+		[&context](ast::expr_tuple_subscript &tuple_subscript_expr) -> ast::constant_value {
 			for (auto &elem : tuple_subscript_expr.base.elems)
 			{
 				consteval_guaranteed(elem, context);
@@ -2802,7 +2808,7 @@ static ast::constant_value_storage guaranteed_evaluate_expr(
 
 			return evaluate_tuple_subscript(tuple_subscript_expr);
 		},
-		[&context](ast::expr_rvalue_tuple_subscript &rvalue_tuple_subscript_expr) -> ast::constant_value_storage {
+		[&context](ast::expr_rvalue_tuple_subscript &rvalue_tuple_subscript_expr) -> ast::constant_value {
 			consteval_guaranteed(rvalue_tuple_subscript_expr.base, context);
 
 			if (rvalue_tuple_subscript_expr.base.is_constant())
@@ -2821,7 +2827,7 @@ static ast::constant_value_storage guaranteed_evaluate_expr(
 				return {};
 			}
 		},
-		[&context](ast::expr_subscript &subscript_expr) -> ast::constant_value_storage {
+		[&context](ast::expr_subscript &subscript_expr) -> ast::constant_value {
 			consteval_guaranteed(subscript_expr.base, context);
 			consteval_guaranteed(subscript_expr.index, context);
 
@@ -2829,20 +2835,20 @@ static ast::constant_value_storage guaranteed_evaluate_expr(
 			// lvalue reference to an rvalue
 			return {};
 		},
-		[&context](ast::expr_rvalue_array_subscript &rvalue_array_subscript_expr) -> ast::constant_value_storage {
+		[&context](ast::expr_rvalue_array_subscript &rvalue_array_subscript_expr) -> ast::constant_value {
 			consteval_guaranteed(rvalue_array_subscript_expr.base, context);
 			consteval_guaranteed(rvalue_array_subscript_expr.index, context);
 
 			return evaluate_subscript(rvalue_array_subscript_expr.base, rvalue_array_subscript_expr.index, context);
 		},
-		[&expr, &context](ast::expr_function_call &func_call) -> ast::constant_value_storage {
+		[&expr, &context](ast::expr_function_call &func_call) -> ast::constant_value {
 			for (auto &param : func_call.params)
 			{
 				consteval_guaranteed(param, context);
 			}
 			return consteval_guaranteed_function_call(expr, func_call, context);
 		},
-		[&context](ast::expr_indirect_function_call &func_call) -> ast::constant_value_storage {
+		[&context](ast::expr_indirect_function_call &func_call) -> ast::constant_value {
 			consteval_guaranteed(func_call.called, context);
 			for (auto &param : func_call.params)
 			{
@@ -2850,7 +2856,7 @@ static ast::constant_value_storage guaranteed_evaluate_expr(
 			}
 			return {};
 		},
-		[&expr, &context](ast::expr_cast &cast_expr) -> ast::constant_value_storage {
+		[&expr, &context](ast::expr_cast &cast_expr) -> ast::constant_value {
 			consteval_guaranteed(cast_expr.expr, context);
 			if (cast_expr.expr.has_consteval_succeeded())
 			{
@@ -2861,11 +2867,11 @@ static ast::constant_value_storage guaranteed_evaluate_expr(
 				return {};
 			}
 		},
-		[&context](ast::expr_bit_cast &bit_cast_expr) -> ast::constant_value_storage {
+		[&context](ast::expr_bit_cast &bit_cast_expr) -> ast::constant_value {
 			consteval_guaranteed(bit_cast_expr.expr, context);
 			return {};
 		},
-		[&context](ast::expr_optional_cast &optional_cast_expr) -> ast::constant_value_storage {
+		[&context](ast::expr_optional_cast &optional_cast_expr) -> ast::constant_value {
 			consteval_guaranteed(optional_cast_expr.expr, context);
 			if (optional_cast_expr.expr.has_consteval_succeeded())
 			{
@@ -2876,13 +2882,13 @@ static ast::constant_value_storage guaranteed_evaluate_expr(
 				return {};
 			}
 		},
-		[](ast::expr_take_reference const &) -> ast::constant_value_storage {
+		[](ast::expr_take_reference const &) -> ast::constant_value {
 			return {};
 		},
-		[](ast::expr_take_move_reference const &) -> ast::constant_value_storage {
+		[](ast::expr_take_move_reference const &) -> ast::constant_value {
 			return {};
 		},
-		[&context](ast::expr_aggregate_init &aggregate_init_expr) -> ast::constant_value_storage {
+		[&context](ast::expr_aggregate_init &aggregate_init_expr) -> ast::constant_value {
 			if (is_special_array_type(aggregate_init_expr.type))
 			{
 				auto result = consteval_guaranteed_special_array_value(aggregate_init_expr.type, aggregate_init_expr.exprs, context);
@@ -2905,13 +2911,12 @@ static ast::constant_value_storage guaranteed_evaluate_expr(
 
 			if (is_special_array_type(aggregate_init_expr.type))
 			{
-				return get_special_array_value(aggregate_init_expr.type, aggregate_init_expr.exprs);
+				return get_special_array_value(aggregate_init_expr.type, aggregate_init_expr.exprs, context);
 			}
 			else if (aggregate_init_expr.type.is<ast::ts_array>())
 			{
 				auto const [elem_type, size, is_multi_dimensional] = get_flattened_array_type_and_size(aggregate_init_expr.type);
-				auto result = ast::constant_value_storage();
-				auto &array = result.emplace<ast::constant_value_kind::array>();
+				auto array = ast::arena_vector<ast::constant_value>();
 				array.reserve(size);
 				if (is_multi_dimensional)
 				{
@@ -2928,25 +2933,24 @@ static ast::constant_value_storage guaranteed_evaluate_expr(
 					}
 				}
 
-				return result;
+				return context.add_constant_array(std::move(array));
 			}
 			else
 			{
-				auto result = ast::constant_value_storage();
-				auto &aggregate = result.emplace<ast::constant_value_kind::aggregate>();
+				auto aggregate = ast::arena_vector<ast::constant_value>();
 				aggregate.reserve(aggregate_init_expr.exprs.size());
 				for (auto const &expr : aggregate_init_expr.exprs)
 				{
 					aggregate.emplace_back(expr.get_constant_value());
 				}
-				return result;
+				return context.add_constant_aggregate(std::move(aggregate));
 			}
 		},
-		[&context](ast::expr_array_value_init &array_value_init_expr) -> ast::constant_value_storage {
+		[&context](ast::expr_array_value_init &array_value_init_expr) -> ast::constant_value {
 			consteval_guaranteed(array_value_init_expr.value, context);
 			return {};
 		},
-		[&context](ast::expr_aggregate_default_construct &aggregate_default_construct_expr) -> ast::constant_value_storage {
+		[&context](ast::expr_aggregate_default_construct &aggregate_default_construct_expr) -> ast::constant_value {
 			bool is_consteval = true;
 			for (auto &expr : aggregate_default_construct_expr.default_construct_exprs)
 			{
@@ -2958,18 +2962,22 @@ static ast::constant_value_storage guaranteed_evaluate_expr(
 				return {};
 			}
 
-			ast::constant_value_storage result{};
-			auto &aggregate = aggregate_default_construct_expr.type.is<ast::ts_tuple>()
-				? result.emplace<ast::constant_value_kind::tuple>()
-				: result.emplace<ast::constant_value_kind::aggregate>();
+			auto aggregate = ast::arena_vector<ast::constant_value>();
 			aggregate.reserve(aggregate_default_construct_expr.default_construct_exprs.size());
 			for (auto const &expr : aggregate_default_construct_expr.default_construct_exprs)
 			{
 				aggregate.emplace_back(expr.get_constant_value());
 			}
-			return result;
+			if (aggregate_default_construct_expr.type.is<ast::ts_tuple>())
+			{
+				return context.add_constant_tuple(std::move(aggregate));
+			}
+			else
+			{
+				return context.add_constant_aggregate(std::move(aggregate));
+			}
 		},
-		[&expr, &context](ast::expr_aggregate_copy_construct &aggregate_copy_construct_expr) -> ast::constant_value_storage {
+		[&expr, &context](ast::expr_aggregate_copy_construct &aggregate_copy_construct_expr) -> ast::constant_value {
 			consteval_guaranteed(aggregate_copy_construct_expr.copied_value, context);
 			if (!aggregate_copy_construct_expr.copied_value.has_consteval_succeeded())
 			{
@@ -2985,11 +2993,11 @@ static ast::constant_value_storage guaranteed_evaluate_expr(
 				return {};
 			}
 		},
-		[&context](ast::expr_aggregate_move_construct &aggregate_move_construct_expr) -> ast::constant_value_storage {
+		[&context](ast::expr_aggregate_move_construct &aggregate_move_construct_expr) -> ast::constant_value {
 			consteval_guaranteed(aggregate_move_construct_expr.moved_value, context);
 			return {};
 		},
-		[&expr, &context](ast::expr_array_default_construct &array_default_construct_expr) -> ast::constant_value_storage {
+		[&expr, &context](ast::expr_array_default_construct &array_default_construct_expr) -> ast::constant_value {
 			auto const type = array_default_construct_expr.type.as_typespec_view();
 			bz_assert(type.is<ast::ts_array>());
 			consteval_guaranteed(array_default_construct_expr.default_construct_expr, context);
@@ -3006,20 +3014,17 @@ static ast::constant_value_storage guaranteed_evaluate_expr(
 			{
 				auto const &value = array_default_construct_expr.default_construct_expr.get_constant_value();
 				auto const [elem_type, size, is_multi_dimensional] = get_flattened_array_type_and_size(type);
-				auto result = ast::constant_value_storage();
 				if (is_multi_dimensional)
 				{
-					bz_assert(value.is_array() && value.get_array().not_empty());
-					result.emplace<ast::constant_value_kind::array>(size, value.get_array()[0]);
+					return context.add_constant_array(ast::arena_vector<ast::constant_value>(size, value.get_array()[0]));
 				}
 				else
 				{
-					result.emplace<ast::constant_value_kind::array>(size, value);
+					return context.add_constant_array(ast::arena_vector<ast::constant_value>(size, value));
 				}
-				return result;
 			}
 		},
-		[&expr, &context](ast::expr_array_copy_construct &array_copy_construct_expr) -> ast::constant_value_storage {
+		[&expr, &context](ast::expr_array_copy_construct &array_copy_construct_expr) -> ast::constant_value {
 			consteval_guaranteed(array_copy_construct_expr.copied_value, context);
 			if (!array_copy_construct_expr.copied_value.has_consteval_succeeded())
 			{
@@ -3035,21 +3040,21 @@ static ast::constant_value_storage guaranteed_evaluate_expr(
 				return {};
 			}
 		},
-		[&context](ast::expr_array_move_construct &array_move_construct_expr) -> ast::constant_value_storage {
+		[&context](ast::expr_array_move_construct &array_move_construct_expr) -> ast::constant_value {
 			consteval_guaranteed(array_move_construct_expr.moved_value, context);
 			return {};
 		},
-		[&expr, &context](ast::expr_optional_default_construct &optional_default_construct_expr) -> ast::constant_value_storage {
+		[&expr, &context](ast::expr_optional_default_construct &optional_default_construct_expr) -> ast::constant_value {
 			if (context.is_trivially_destructible(expr.src_tokens, optional_default_construct_expr.type))
 			{
-				return ast::constant_value_storage::get_null();
+				return ast::constant_value::get_null();
 			}
 			else
 			{
 				return {};
 			}
 		},
-		[&expr, &context](ast::expr_optional_copy_construct &optional_copy_construct_expr) -> ast::constant_value_storage {
+		[&expr, &context](ast::expr_optional_copy_construct &optional_copy_construct_expr) -> ast::constant_value {
 			consteval_guaranteed(optional_copy_construct_expr.copied_value, context);
 			if (!optional_copy_construct_expr.copied_value.has_consteval_succeeded())
 			{
@@ -3065,7 +3070,7 @@ static ast::constant_value_storage guaranteed_evaluate_expr(
 				return {};
 			}
 		},
-		[&expr, &context](ast::expr_optional_move_construct &optional_move_construct_expr) -> ast::constant_value_storage {
+		[&expr, &context](ast::expr_optional_move_construct &optional_move_construct_expr) -> ast::constant_value {
 			consteval_guaranteed(optional_move_construct_expr.moved_value, context);
 			if (!optional_move_construct_expr.moved_value.has_consteval_succeeded())
 			{
@@ -3081,11 +3086,11 @@ static ast::constant_value_storage guaranteed_evaluate_expr(
 				return {};
 			}
 		},
-		[](ast::expr_builtin_default_construct &builtin_default_construct_expr) -> ast::constant_value_storage {
+		[](ast::expr_builtin_default_construct &builtin_default_construct_expr) -> ast::constant_value {
 			bz_assert(builtin_default_construct_expr.type.is<ast::ts_array_slice>());
 			return {};
 		},
-		[&context](ast::expr_trivial_copy_construct &trivial_copy_construct_expr) -> ast::constant_value_storage {
+		[&context](ast::expr_trivial_copy_construct &trivial_copy_construct_expr) -> ast::constant_value {
 			consteval_guaranteed(trivial_copy_construct_expr.copied_value, context);
 			if (!trivial_copy_construct_expr.copied_value.has_consteval_succeeded())
 			{
@@ -3094,65 +3099,65 @@ static ast::constant_value_storage guaranteed_evaluate_expr(
 
 			return trivial_copy_construct_expr.copied_value.get_constant_value();
 		},
-		[&context](ast::expr_trivial_relocate &trivial_relocate_expr) -> ast::constant_value_storage {
+		[&context](ast::expr_trivial_relocate &trivial_relocate_expr) -> ast::constant_value {
 			consteval_guaranteed(trivial_relocate_expr.value, context);
 			return {};
 		},
-		[](ast::expr_aggregate_destruct &) -> ast::constant_value_storage {
+		[](ast::expr_aggregate_destruct &) -> ast::constant_value {
 			return {};
 		},
-		[](ast::expr_array_destruct &) -> ast::constant_value_storage {
+		[](ast::expr_array_destruct &) -> ast::constant_value {
 			return {};
 		},
-		[](ast::expr_optional_destruct &) -> ast::constant_value_storage {
+		[](ast::expr_optional_destruct &) -> ast::constant_value {
 			return {};
 		},
-		[](ast::expr_base_type_destruct &) -> ast::constant_value_storage {
+		[](ast::expr_base_type_destruct &) -> ast::constant_value {
 			return {};
 		},
-		[](ast::expr_destruct_value &) -> ast::constant_value_storage {
+		[](ast::expr_destruct_value &) -> ast::constant_value {
 			return {};
 		},
-		[](ast::expr_aggregate_assign &) -> ast::constant_value_storage {
+		[](ast::expr_aggregate_assign &) -> ast::constant_value {
 			return {};
 		},
-		[](ast::expr_array_assign &) -> ast::constant_value_storage {
+		[](ast::expr_array_assign &) -> ast::constant_value {
 			return {};
 		},
-		[](ast::expr_optional_assign &) -> ast::constant_value_storage {
+		[](ast::expr_optional_assign &) -> ast::constant_value {
 			return {};
 		},
-		[](ast::expr_optional_null_assign &) -> ast::constant_value_storage {
+		[](ast::expr_optional_null_assign &) -> ast::constant_value {
 			return {};
 		},
-		[](ast::expr_optional_value_assign &) -> ast::constant_value_storage {
+		[](ast::expr_optional_value_assign &) -> ast::constant_value {
 			return {};
 		},
-		[](ast::expr_optional_reference_value_assign &) -> ast::constant_value_storage {
+		[](ast::expr_optional_reference_value_assign &) -> ast::constant_value {
 			return {};
 		},
-		[](ast::expr_base_type_assign &) -> ast::constant_value_storage {
+		[](ast::expr_base_type_assign &) -> ast::constant_value {
 			return {};
 		},
-		[](ast::expr_trivial_assign &) -> ast::constant_value_storage {
+		[](ast::expr_trivial_assign &) -> ast::constant_value {
 			return {};
 		},
-		[](ast::expr_aggregate_swap &) -> ast::constant_value_storage {
+		[](ast::expr_aggregate_swap &) -> ast::constant_value {
 			return {};
 		},
-		[](ast::expr_array_swap &) -> ast::constant_value_storage {
+		[](ast::expr_array_swap &) -> ast::constant_value {
 			return {};
 		},
-		[](ast::expr_optional_swap &) -> ast::constant_value_storage {
+		[](ast::expr_optional_swap &) -> ast::constant_value {
 			return {};
 		},
-		[](ast::expr_base_type_swap &) -> ast::constant_value_storage {
+		[](ast::expr_base_type_swap &) -> ast::constant_value {
 			return {};
 		},
-		[](ast::expr_trivial_swap &) -> ast::constant_value_storage {
+		[](ast::expr_trivial_swap &) -> ast::constant_value {
 			return {};
 		},
-		[&context](ast::expr_member_access &member_access_expr) -> ast::constant_value_storage {
+		[&context](ast::expr_member_access &member_access_expr) -> ast::constant_value {
 			consteval_guaranteed(member_access_expr.base, context);
 			if (member_access_expr.base.has_consteval_succeeded())
 			{
@@ -3166,7 +3171,7 @@ static ast::constant_value_storage guaranteed_evaluate_expr(
 				return {};
 			}
 		},
-		[&context, &expr](ast::expr_optional_extract_value &optional_extract_value) -> ast::constant_value_storage {
+		[&context, &expr](ast::expr_optional_extract_value &optional_extract_value) -> ast::constant_value {
 			consteval_guaranteed(optional_extract_value.optional_value, context);
 			if (optional_extract_value.optional_value.has_consteval_succeeded())
 			{
@@ -3190,7 +3195,7 @@ static ast::constant_value_storage guaranteed_evaluate_expr(
 				return {};
 			}
 		},
-		[&context](ast::expr_rvalue_member_access &rvalue_member_access_expr) -> ast::constant_value_storage {
+		[&context](ast::expr_rvalue_member_access &rvalue_member_access_expr) -> ast::constant_value {
 			consteval_guaranteed(rvalue_member_access_expr.base, context);
 			if (rvalue_member_access_expr.base.has_consteval_succeeded())
 			{
@@ -3204,24 +3209,24 @@ static ast::constant_value_storage guaranteed_evaluate_expr(
 				return {};
 			}
 		},
-		[](ast::expr_type_member_access &) -> ast::constant_value_storage {
+		[](ast::expr_type_member_access &) -> ast::constant_value {
 			// variable constevalness is handled in parse_context::make_member_access_expression
 			return {};
 		},
-		[&context](ast::expr_compound &compound_expr) -> ast::constant_value_storage {
+		[&context](ast::expr_compound &compound_expr) -> ast::constant_value {
 			if (compound_expr.statements.empty() && compound_expr.final_expr.not_null())
 			{
 				consteval_guaranteed(compound_expr.final_expr, context);
 			}
 			return {};
 		},
-		[&context](ast::expr_if &if_expr) -> ast::constant_value_storage {
+		[&context](ast::expr_if &if_expr) -> ast::constant_value {
 			consteval_guaranteed(if_expr.condition, context);
 			consteval_guaranteed(if_expr.then_block, context);
 			consteval_guaranteed(if_expr.else_block, context);
 			return {};
 		},
-		[&context](ast::expr_if_consteval &if_expr) -> ast::constant_value_storage {
+		[&context](ast::expr_if_consteval &if_expr) -> ast::constant_value {
 			bz_assert(if_expr.condition.is_constant());
 			auto const &condition_value = if_expr.condition.get_constant_value();
 			bz_assert(condition_value.is_boolean());
@@ -3253,10 +3258,10 @@ static ast::constant_value_storage guaranteed_evaluate_expr(
 			}
 			else
 			{
-				return ast::constant_value_storage::get_void();
+				return ast::constant_value::get_void();
 			}
 		},
-		[&context](ast::expr_switch &switch_expr) -> ast::constant_value_storage {
+		[&context](ast::expr_switch &switch_expr) -> ast::constant_value {
 			consteval_guaranteed(switch_expr.matched_expr, context);
 			for (auto &[_, case_expr] : switch_expr.cases)
 			{
@@ -3265,25 +3270,25 @@ static ast::constant_value_storage guaranteed_evaluate_expr(
 			consteval_guaranteed(switch_expr.default_case, context);
 			return {};
 		},
-		[](ast::expr_break &) -> ast::constant_value_storage {
+		[](ast::expr_break &) -> ast::constant_value {
 			return {};
 		},
-		[](ast::expr_continue &) -> ast::constant_value_storage {
+		[](ast::expr_continue &) -> ast::constant_value {
 			return {};
 		},
-		[](ast::expr_unreachable &) -> ast::constant_value_storage {
+		[](ast::expr_unreachable &) -> ast::constant_value {
 			return {};
 		},
-		[](ast::expr_generic_type_instantiation &) -> ast::constant_value_storage {
+		[](ast::expr_generic_type_instantiation &) -> ast::constant_value {
 			bz_unreachable;
 		},
-		[](ast::expr_bitcode_value_reference &) -> ast::constant_value_storage {
+		[](ast::expr_bitcode_value_reference &) -> ast::constant_value {
 			return {};
 		},
 	});
 }
 
-static ast::constant_value_storage try_evaluate_expr(
+static ast::constant_value try_evaluate_expr(
 	ast::expression &expr,
 	ctx::parse_context &context
 )
@@ -3292,7 +3297,7 @@ static ast::constant_value_storage try_evaluate_expr(
 	return context.execute_expression(expr);
 }
 
-static ast::constant_value_storage try_evaluate_expr_without_error(
+static ast::constant_value try_evaluate_expr_without_error(
 	ast::expression &expr,
 	ctx::parse_context &context
 )

--- a/src/resolve/consteval.cpp
+++ b/src/resolve/consteval.cpp
@@ -77,7 +77,7 @@ static ast::constant_value_storage evaluate_binary_plus(
 		switch (lhs_value.kind())
 		{
 		static_assert(ast::constant_value_storage::variant_count == 19);
-		case ast::constant_value_storage::sint:
+		case ast::constant_value_kind::sint:
 		{
 			auto const lhs_int_val = lhs_value.get_sint();
 			auto const rhs_int_val = rhs_value.get_sint();
@@ -86,7 +86,7 @@ static ast::constant_value_storage evaluate_binary_plus(
 				lhs_int_val, rhs_int_val, type, context
 			));
 		}
-		case ast::constant_value_storage::uint:
+		case ast::constant_value_kind::uint:
 		{
 			auto const lhs_int_val = lhs_value.get_uint();
 			auto const rhs_int_val = rhs_value.get_uint();
@@ -95,7 +95,7 @@ static ast::constant_value_storage evaluate_binary_plus(
 				lhs_int_val, rhs_int_val, type, context
 			));
 		}
-		case ast::constant_value_storage::float32:
+		case ast::constant_value_kind::float32:
 		{
 			auto const lhs_float_val = lhs_value.get_float32();
 			auto const rhs_float_val = rhs_value.get_float32();
@@ -104,7 +104,7 @@ static ast::constant_value_storage evaluate_binary_plus(
 				lhs_float_val, rhs_float_val, context
 			));
 		}
-		case ast::constant_value_storage::float64:
+		case ast::constant_value_kind::float64:
 		{
 			auto const lhs_float_val = lhs_value.get_float64();
 			auto const rhs_float_val = rhs_value.get_float64();
@@ -188,7 +188,7 @@ static ast::constant_value_storage evaluate_binary_minus(
 		switch (lhs_value.kind())
 		{
 		static_assert(ast::constant_value_storage::variant_count == 19);
-		case ast::constant_value_storage::sint:
+		case ast::constant_value_kind::sint:
 		{
 			auto const lhs_int_val = lhs_value.get_sint();
 			auto const rhs_int_val = rhs_value.get_sint();
@@ -197,7 +197,7 @@ static ast::constant_value_storage evaluate_binary_minus(
 				lhs_int_val, rhs_int_val, type, context
 			));
 		}
-		case ast::constant_value_storage::uint:
+		case ast::constant_value_kind::uint:
 		{
 			auto const lhs_int_val = lhs_value.get_uint();
 			auto const rhs_int_val = rhs_value.get_uint();
@@ -206,7 +206,7 @@ static ast::constant_value_storage evaluate_binary_minus(
 				lhs_int_val, rhs_int_val, type, context
 			));
 		}
-		case ast::constant_value_storage::float32:
+		case ast::constant_value_kind::float32:
 		{
 			auto const lhs_float_val = lhs_value.get_float32();
 			auto const rhs_float_val = rhs_value.get_float32();
@@ -215,7 +215,7 @@ static ast::constant_value_storage evaluate_binary_minus(
 				lhs_float_val, rhs_float_val, context
 			));
 		}
-		case ast::constant_value_storage::float64:
+		case ast::constant_value_kind::float64:
 		{
 			auto const lhs_float_val = lhs_value.get_float64();
 			auto const rhs_float_val = rhs_value.get_float64();
@@ -224,7 +224,7 @@ static ast::constant_value_storage evaluate_binary_minus(
 				lhs_float_val, rhs_float_val, context
 			));
 		}
-		case ast::constant_value_storage::u8char:
+		case ast::constant_value_kind::u8char:
 			return ast::constant_value_storage(
 				static_cast<int64_t>(lhs_value.get_u8char())
 				- static_cast<int64_t>(rhs_value.get_u8char())
@@ -279,7 +279,7 @@ static ast::constant_value_storage evaluate_binary_multiply(
 	switch (lhs_value.kind())
 	{
 	static_assert(ast::constant_value_storage::variant_count == 19);
-	case ast::constant_value_storage::sint:
+	case ast::constant_value_kind::sint:
 	{
 		auto const lhs_int_val = lhs_value.get_sint();
 		auto const rhs_int_val = rhs_value.get_sint();
@@ -288,7 +288,7 @@ static ast::constant_value_storage evaluate_binary_multiply(
 			lhs_int_val, rhs_int_val, type, context
 		));
 	}
-	case ast::constant_value_storage::uint:
+	case ast::constant_value_kind::uint:
 	{
 		auto const lhs_int_val = lhs_value.get_uint();
 		auto const rhs_int_val = rhs_value.get_uint();
@@ -297,7 +297,7 @@ static ast::constant_value_storage evaluate_binary_multiply(
 			lhs_int_val, rhs_int_val, type, context
 		));
 	}
-	case ast::constant_value_storage::float32:
+	case ast::constant_value_kind::float32:
 	{
 		auto const lhs_float_val = lhs_value.get_float32();
 		auto const rhs_float_val = rhs_value.get_float32();
@@ -306,7 +306,7 @@ static ast::constant_value_storage evaluate_binary_multiply(
 			lhs_float_val, rhs_float_val, context
 		));
 	}
-	case ast::constant_value_storage::float64:
+	case ast::constant_value_kind::float64:
 	{
 		auto const lhs_float_val = lhs_value.get_float64();
 		auto const rhs_float_val = rhs_value.get_float64();
@@ -339,7 +339,7 @@ static ast::constant_value_storage evaluate_binary_divide(
 	switch (lhs_value.kind())
 	{
 	static_assert(ast::constant_value_storage::variant_count == 19);
-	case ast::constant_value_storage::sint:
+	case ast::constant_value_kind::sint:
 	{
 		auto const lhs_int_val = lhs_value.get_sint();
 		auto const rhs_int_val = rhs_value.get_sint();
@@ -356,7 +356,7 @@ static ast::constant_value_storage evaluate_binary_divide(
 			return {};
 		}
 	}
-	case ast::constant_value_storage::uint:
+	case ast::constant_value_kind::uint:
 	{
 		auto const lhs_int_val = lhs_value.get_uint();
 		auto const rhs_int_val = rhs_value.get_uint();
@@ -373,7 +373,7 @@ static ast::constant_value_storage evaluate_binary_divide(
 			return {};
 		}
 	}
-	case ast::constant_value_storage::float32:
+	case ast::constant_value_kind::float32:
 	{
 		auto const lhs_float_val = lhs_value.get_float32();
 		auto const rhs_float_val = rhs_value.get_float32();
@@ -382,7 +382,7 @@ static ast::constant_value_storage evaluate_binary_divide(
 			lhs_float_val, rhs_float_val, context
 		));
 	}
-	case ast::constant_value_storage::float64:
+	case ast::constant_value_kind::float64:
 	{
 		auto const lhs_float_val = lhs_value.get_float64();
 		auto const rhs_float_val = rhs_value.get_float64();
@@ -415,7 +415,7 @@ static ast::constant_value_storage evaluate_binary_modulo(
 	switch (lhs_value.kind())
 	{
 	static_assert(ast::constant_value_storage::variant_count == 19);
-	case ast::constant_value_storage::sint:
+	case ast::constant_value_kind::sint:
 	{
 		auto const lhs_int_val = lhs_value.get_sint();
 		auto const rhs_int_val = rhs_value.get_sint();
@@ -432,7 +432,7 @@ static ast::constant_value_storage evaluate_binary_modulo(
 			return {};
 		}
 	}
-	case ast::constant_value_storage::uint:
+	case ast::constant_value_kind::uint:
 	{
 		auto const lhs_int_val = lhs_value.get_uint();
 		auto const rhs_int_val = rhs_value.get_uint();
@@ -472,19 +472,19 @@ static ast::constant_value_storage evaluate_binary_equals(
 	switch (lhs_value.kind())
 	{
 	static_assert(ast::constant_value_storage::variant_count == 19);
-	case ast::constant_value_storage::sint:
+	case ast::constant_value_kind::sint:
 	{
 		auto const lhs_int_val = lhs_value.get_sint();
 		auto const rhs_int_val = rhs_value.get_sint();
 		return ast::constant_value_storage(lhs_int_val == rhs_int_val);
 	}
-	case ast::constant_value_storage::uint:
+	case ast::constant_value_kind::uint:
 	{
 		auto const lhs_int_val = lhs_value.get_uint();
 		auto const rhs_int_val = rhs_value.get_uint();
 		return ast::constant_value_storage(lhs_int_val == rhs_int_val);
 	}
-	case ast::constant_value_storage::float32:
+	case ast::constant_value_kind::float32:
 	{
 		auto const lhs_float_val = lhs_value.get_float32();
 		auto const rhs_float_val = rhs_value.get_float32();
@@ -493,7 +493,7 @@ static ast::constant_value_storage evaluate_binary_equals(
 			lhs_float_val, rhs_float_val, context
 		));
 	}
-	case ast::constant_value_storage::float64:
+	case ast::constant_value_kind::float64:
 	{
 		auto const lhs_float_val = lhs_value.get_float64();
 		auto const rhs_float_val = rhs_value.get_float64();
@@ -502,29 +502,29 @@ static ast::constant_value_storage evaluate_binary_equals(
 			lhs_float_val, rhs_float_val, context
 		));
 	}
-	case ast::constant_value_storage::u8char:
+	case ast::constant_value_kind::u8char:
 	{
 		auto const lhs_char_val = lhs_value.get_u8char();
 		auto const rhs_char_val = rhs_value.get_u8char();
 		return ast::constant_value_storage(lhs_char_val == rhs_char_val);
 	}
-	case ast::constant_value_storage::boolean:
+	case ast::constant_value_kind::boolean:
 	{
 		auto const lhs_bool_val = lhs_value.get_boolean();
 		auto const rhs_bool_val = rhs_value.get_boolean();
 		return ast::constant_value_storage(lhs_bool_val == rhs_bool_val);
 	}
-	case ast::constant_value_storage::string:
+	case ast::constant_value_kind::string:
 	{
 		auto const lhs_str_val = lhs_value.get_string();
 		auto const rhs_str_val = rhs_value.get_string();
 		return ast::constant_value_storage(lhs_str_val == rhs_str_val);
 	}
-	case ast::constant_value_storage::null:
+	case ast::constant_value_kind::null:
 	{
 		return ast::constant_value_storage(true);
 	}
-	case ast::constant_value_storage::enum_:
+	case ast::constant_value_kind::enum_:
 	{
 		auto const lhs_enum_value = lhs_value.get_enum().value;
 		auto const rhs_enum_value = rhs_value.get_enum().value;
@@ -553,53 +553,53 @@ static ast::constant_value_storage evaluate_binary_not_equals(
 	switch (lhs_value.kind())
 	{
 	static_assert(ast::constant_value_storage::variant_count == 19);
-	case ast::constant_value_storage::sint:
+	case ast::constant_value_kind::sint:
 	{
 		auto const lhs_int_val = lhs_value.get_sint();
 		auto const rhs_int_val = rhs_value.get_sint();
 		return ast::constant_value_storage(lhs_int_val != rhs_int_val);
 	}
-	case ast::constant_value_storage::uint:
+	case ast::constant_value_kind::uint:
 	{
 		auto const lhs_int_val = lhs_value.get_uint();
 		auto const rhs_int_val = rhs_value.get_uint();
 		return ast::constant_value_storage(lhs_int_val != rhs_int_val);
 	}
-	case ast::constant_value_storage::float32:
+	case ast::constant_value_kind::float32:
 	{
 		auto const lhs_float_val = lhs_value.get_float32();
 		auto const rhs_float_val = rhs_value.get_float32();
 		return ast::constant_value_storage(lhs_float_val != rhs_float_val);
 	}
-	case ast::constant_value_storage::float64:
+	case ast::constant_value_kind::float64:
 	{
 		auto const lhs_float_val = lhs_value.get_float64();
 		auto const rhs_float_val = rhs_value.get_float64();
 		return ast::constant_value_storage(lhs_float_val != rhs_float_val);
 	}
-	case ast::constant_value_storage::u8char:
+	case ast::constant_value_kind::u8char:
 	{
 		auto const lhs_char_val = lhs_value.get_u8char();
 		auto const rhs_char_val = rhs_value.get_u8char();
 		return ast::constant_value_storage(lhs_char_val != rhs_char_val);
 	}
-	case ast::constant_value_storage::boolean:
+	case ast::constant_value_kind::boolean:
 	{
 		auto const lhs_bool_val = lhs_value.get_boolean();
 		auto const rhs_bool_val = rhs_value.get_boolean();
 		return ast::constant_value_storage(lhs_bool_val != rhs_bool_val);
 	}
-	case ast::constant_value_storage::string:
+	case ast::constant_value_kind::string:
 	{
 		auto const lhs_str_val = lhs_value.get_string();
 		auto const rhs_str_val = rhs_value.get_string();
 		return ast::constant_value_storage(lhs_str_val != rhs_str_val);
 	}
-	case ast::constant_value_storage::null:
+	case ast::constant_value_kind::null:
 	{
 		return ast::constant_value_storage(false);
 	}
-	case ast::constant_value_storage::enum_:
+	case ast::constant_value_kind::enum_:
 	{
 		auto const lhs_enum_value = lhs_value.get_enum().value;
 		auto const rhs_enum_value = rhs_value.get_enum().value;
@@ -628,41 +628,41 @@ static ast::constant_value_storage evaluate_binary_less_than(
 	switch (lhs_value.kind())
 	{
 	static_assert(ast::constant_value_storage::variant_count == 19);
-	case ast::constant_value_storage::sint:
+	case ast::constant_value_kind::sint:
 	{
 		auto const lhs_int_val = lhs_value.get_sint();
 		auto const rhs_int_val = rhs_value.get_sint();
 		return ast::constant_value_storage(lhs_int_val < rhs_int_val);
 	}
-	case ast::constant_value_storage::uint:
+	case ast::constant_value_kind::uint:
 	{
 		auto const lhs_int_val = lhs_value.get_uint();
 		auto const rhs_int_val = rhs_value.get_uint();
 		return ast::constant_value_storage(lhs_int_val < rhs_int_val);
 	}
-	case ast::constant_value_storage::float32:
+	case ast::constant_value_kind::float32:
 	{
 		auto const lhs_float_val = lhs_value.get_float32();
 		auto const rhs_float_val = rhs_value.get_float32();
 		return ast::constant_value_storage(lhs_float_val < rhs_float_val);
 	}
-	case ast::constant_value_storage::float64:
+	case ast::constant_value_kind::float64:
 	{
 		auto const lhs_float_val = lhs_value.get_float64();
 		auto const rhs_float_val = rhs_value.get_float64();
 		return ast::constant_value_storage(lhs_float_val < rhs_float_val);
 	}
-	case ast::constant_value_storage::u8char:
+	case ast::constant_value_kind::u8char:
 	{
 		auto const lhs_char_val = lhs_value.get_u8char();
 		auto const rhs_char_val = rhs_value.get_u8char();
 		return ast::constant_value_storage(lhs_char_val < rhs_char_val);
 	}
-	case ast::constant_value_storage::null:
+	case ast::constant_value_kind::null:
 	{
 		return ast::constant_value_storage(false);
 	}
-	case ast::constant_value_storage::enum_:
+	case ast::constant_value_kind::enum_:
 	{
 		auto const [decl, lhs_enum_value] = lhs_value.get_enum();
 		auto const rhs_enum_value = rhs_value.get_enum().value;
@@ -694,41 +694,41 @@ static ast::constant_value_storage evaluate_binary_less_than_eq(
 	switch (lhs_value.kind())
 	{
 	static_assert(ast::constant_value_storage::variant_count == 19);
-	case ast::constant_value_storage::sint:
+	case ast::constant_value_kind::sint:
 	{
 		auto const lhs_int_val = lhs_value.get_sint();
 		auto const rhs_int_val = rhs_value.get_sint();
 		return ast::constant_value_storage(lhs_int_val <= rhs_int_val);
 	}
-	case ast::constant_value_storage::uint:
+	case ast::constant_value_kind::uint:
 	{
 		auto const lhs_int_val = lhs_value.get_uint();
 		auto const rhs_int_val = rhs_value.get_uint();
 		return ast::constant_value_storage(lhs_int_val <= rhs_int_val);
 	}
-	case ast::constant_value_storage::float32:
+	case ast::constant_value_kind::float32:
 	{
 		auto const lhs_float_val = lhs_value.get_float32();
 		auto const rhs_float_val = rhs_value.get_float32();
 		return ast::constant_value_storage(lhs_float_val <= rhs_float_val);
 	}
-	case ast::constant_value_storage::float64:
+	case ast::constant_value_kind::float64:
 	{
 		auto const lhs_float_val = lhs_value.get_float64();
 		auto const rhs_float_val = rhs_value.get_float64();
 		return ast::constant_value_storage(lhs_float_val <= rhs_float_val);
 	}
-	case ast::constant_value_storage::u8char:
+	case ast::constant_value_kind::u8char:
 	{
 		auto const lhs_char_val = lhs_value.get_u8char();
 		auto const rhs_char_val = rhs_value.get_u8char();
 		return ast::constant_value_storage(lhs_char_val <= rhs_char_val);
 	}
-	case ast::constant_value_storage::null:
+	case ast::constant_value_kind::null:
 	{
 		return ast::constant_value_storage(true);
 	}
-	case ast::constant_value_storage::enum_:
+	case ast::constant_value_kind::enum_:
 	{
 		auto const [decl, lhs_enum_value] = lhs_value.get_enum();
 		auto const rhs_enum_value = rhs_value.get_enum().value;
@@ -760,41 +760,41 @@ static ast::constant_value_storage evaluate_binary_greater_than(
 	switch (lhs_value.kind())
 	{
 	static_assert(ast::constant_value_storage::variant_count == 19);
-	case ast::constant_value_storage::sint:
+	case ast::constant_value_kind::sint:
 	{
 		auto const lhs_int_val = lhs_value.get_sint();
 		auto const rhs_int_val = rhs_value.get_sint();
 		return ast::constant_value_storage(lhs_int_val > rhs_int_val);
 	}
-	case ast::constant_value_storage::uint:
+	case ast::constant_value_kind::uint:
 	{
 		auto const lhs_int_val = lhs_value.get_uint();
 		auto const rhs_int_val = rhs_value.get_uint();
 		return ast::constant_value_storage(lhs_int_val > rhs_int_val);
 	}
-	case ast::constant_value_storage::float32:
+	case ast::constant_value_kind::float32:
 	{
 		auto const lhs_float_val = lhs_value.get_float32();
 		auto const rhs_float_val = rhs_value.get_float32();
 		return ast::constant_value_storage(lhs_float_val > rhs_float_val);
 	}
-	case ast::constant_value_storage::float64:
+	case ast::constant_value_kind::float64:
 	{
 		auto const lhs_float_val = lhs_value.get_float64();
 		auto const rhs_float_val = rhs_value.get_float64();
 		return ast::constant_value_storage(lhs_float_val > rhs_float_val);
 	}
-	case ast::constant_value_storage::u8char:
+	case ast::constant_value_kind::u8char:
 	{
 		auto const lhs_char_val = lhs_value.get_u8char();
 		auto const rhs_char_val = rhs_value.get_u8char();
 		return ast::constant_value_storage(lhs_char_val > rhs_char_val);
 	}
-	case ast::constant_value_storage::null:
+	case ast::constant_value_kind::null:
 	{
 		return ast::constant_value_storage(false);
 	}
-	case ast::constant_value_storage::enum_:
+	case ast::constant_value_kind::enum_:
 	{
 		auto const [decl, lhs_enum_value] = lhs_value.get_enum();
 		auto const rhs_enum_value = rhs_value.get_enum().value;
@@ -826,41 +826,41 @@ static ast::constant_value_storage evaluate_binary_greater_than_eq(
 	switch (lhs_value.kind())
 	{
 	static_assert(ast::constant_value_storage::variant_count == 19);
-	case ast::constant_value_storage::sint:
+	case ast::constant_value_kind::sint:
 	{
 		auto const lhs_int_val = lhs_value.get_sint();
 		auto const rhs_int_val = rhs_value.get_sint();
 		return ast::constant_value_storage(lhs_int_val >= rhs_int_val);
 	}
-	case ast::constant_value_storage::uint:
+	case ast::constant_value_kind::uint:
 	{
 		auto const lhs_int_val = lhs_value.get_uint();
 		auto const rhs_int_val = rhs_value.get_uint();
 		return ast::constant_value_storage(lhs_int_val >= rhs_int_val);
 	}
-	case ast::constant_value_storage::float32:
+	case ast::constant_value_kind::float32:
 	{
 		auto const lhs_float_val = lhs_value.get_float32();
 		auto const rhs_float_val = rhs_value.get_float32();
 		return ast::constant_value_storage(lhs_float_val >= rhs_float_val);
 	}
-	case ast::constant_value_storage::float64:
+	case ast::constant_value_kind::float64:
 	{
 		auto const lhs_float_val = lhs_value.get_float64();
 		auto const rhs_float_val = rhs_value.get_float64();
 		return ast::constant_value_storage(lhs_float_val >= rhs_float_val);
 	}
-	case ast::constant_value_storage::u8char:
+	case ast::constant_value_kind::u8char:
 	{
 		auto const lhs_char_val = lhs_value.get_u8char();
 		auto const rhs_char_val = rhs_value.get_u8char();
 		return ast::constant_value_storage(lhs_char_val >= rhs_char_val);
 	}
-	case ast::constant_value_storage::null:
+	case ast::constant_value_kind::null:
 	{
 		return ast::constant_value_storage(true);
 	}
-	case ast::constant_value_storage::enum_:
+	case ast::constant_value_kind::enum_:
 	{
 		auto const [decl, lhs_enum_value] = lhs_value.get_enum();
 		auto const rhs_enum_value = rhs_value.get_enum().value;
@@ -892,13 +892,13 @@ static ast::constant_value_storage evaluate_binary_bit_and(
 	switch (lhs_value.kind())
 	{
 	static_assert(ast::constant_value_storage::variant_count == 19);
-	case ast::constant_value_storage::uint:
+	case ast::constant_value_kind::uint:
 	{
 		auto const lhs_int_val = lhs_value.get_uint();
 		auto const rhs_int_val = rhs_value.get_uint();
 		return ast::constant_value_storage(lhs_int_val & rhs_int_val);
 	}
-	case ast::constant_value_storage::boolean:
+	case ast::constant_value_kind::boolean:
 	{
 		auto const lhs_bool_val = lhs_value.get_boolean();
 		auto const rhs_bool_val = rhs_value.get_boolean();
@@ -927,13 +927,13 @@ static ast::constant_value_storage evaluate_binary_bit_xor(
 	switch (lhs_value.kind())
 	{
 	static_assert(ast::constant_value_storage::variant_count == 19);
-	case ast::constant_value_storage::uint:
+	case ast::constant_value_kind::uint:
 	{
 		auto const lhs_int_val = lhs_value.get_uint();
 		auto const rhs_int_val = rhs_value.get_uint();
 		return ast::constant_value_storage(lhs_int_val ^ rhs_int_val);
 	}
-	case ast::constant_value_storage::boolean:
+	case ast::constant_value_kind::boolean:
 	{
 		auto const lhs_bool_val = lhs_value.get_boolean();
 		auto const rhs_bool_val = rhs_value.get_boolean();
@@ -962,13 +962,13 @@ static ast::constant_value_storage evaluate_binary_bit_or(
 	switch (lhs_value.kind())
 	{
 	static_assert(ast::constant_value_storage::variant_count == 19);
-	case ast::constant_value_storage::uint:
+	case ast::constant_value_kind::uint:
 	{
 		auto const lhs_int_val = lhs_value.get_uint();
 		auto const rhs_int_val = rhs_value.get_uint();
 		return ast::constant_value_storage(lhs_int_val | rhs_int_val);
 	}
-	case ast::constant_value_storage::boolean:
+	case ast::constant_value_kind::boolean:
 	{
 		auto const lhs_bool_val = lhs_value.get_boolean();
 		auto const rhs_bool_val = rhs_value.get_boolean();
@@ -1342,47 +1342,47 @@ static ast::constant_value_storage evaluate_subscript(
 			auto const [inner_elem_type, inner_size, is_multi_dimensional] = get_flattened_array_type_and_size(elem_type);
 			auto const begin_index = index_value * inner_size;
 			auto const end_index = begin_index + inner_size;
-			switch (value.index())
+			switch (value.kind())
 			{
 			static_assert(ast::constant_value_storage::variant_count == 19);
-			case ast::constant_value_storage::array:
+			case ast::constant_value_kind::array:
 			{
 				auto const &array_value = value.get_array();
 				bz_assert(end_index <= array_value.size());
 				auto result = ast::constant_value_storage();
-				result.emplace<ast::constant_value_storage::array>(array_value.slice(begin_index, end_index));
+				result.emplace<ast::constant_value_kind::array>(array_value.slice(begin_index, end_index));
 				return result;
 			}
-			case ast::constant_value_storage::sint_array:
+			case ast::constant_value_kind::sint_array:
 			{
 				auto const &array_value = value.get_sint_array();
 				bz_assert(end_index <= array_value.size());
 				auto result = ast::constant_value_storage();
-				result.emplace<ast::constant_value_storage::sint_array>(array_value.slice(begin_index, end_index));
+				result.emplace<ast::constant_value_kind::sint_array>(array_value.slice(begin_index, end_index));
 				return result;
 			}
-			case ast::constant_value_storage::uint_array:
+			case ast::constant_value_kind::uint_array:
 			{
 				auto const &array_value = value.get_uint_array();
 				bz_assert(end_index <= array_value.size());
 				auto result = ast::constant_value_storage();
-				result.emplace<ast::constant_value_storage::uint_array>(array_value.slice(begin_index, end_index));
+				result.emplace<ast::constant_value_kind::uint_array>(array_value.slice(begin_index, end_index));
 				return result;
 			}
-			case ast::constant_value_storage::float32_array:
+			case ast::constant_value_kind::float32_array:
 			{
 				auto const &array_value = value.get_float32_array();
 				bz_assert(end_index <= array_value.size());
 				auto result = ast::constant_value_storage();
-				result.emplace<ast::constant_value_storage::float32_array>(array_value.slice(begin_index, end_index));
+				result.emplace<ast::constant_value_kind::float32_array>(array_value.slice(begin_index, end_index));
 				return result;
 			}
-			case ast::constant_value_storage::float64_array:
+			case ast::constant_value_kind::float64_array:
 			{
 				auto const &array_value = value.get_float64_array();
 				bz_assert(end_index <= array_value.size());
 				auto result = ast::constant_value_storage();
-				result.emplace<ast::constant_value_storage::float64_array>(array_value.slice(begin_index, end_index));
+				result.emplace<ast::constant_value_kind::float64_array>(array_value.slice(begin_index, end_index));
 				return result;
 			}
 			default:
@@ -1391,34 +1391,34 @@ static ast::constant_value_storage evaluate_subscript(
 		}
 		else
 		{
-			switch (value.index())
+			switch (value.kind())
 			{
 			static_assert(ast::constant_value_storage::variant_count == 19);
-			case ast::constant_value_storage::array:
+			case ast::constant_value_kind::array:
 			{
 				auto const &array_value = value.get_array();
 				bz_assert(index_value < array_value.size());
 				return array_value[index_value];
 			}
-			case ast::constant_value_storage::sint_array:
+			case ast::constant_value_kind::sint_array:
 			{
 				auto const &array_value = value.get_sint_array();
 				bz_assert(index_value < array_value.size());
 				return ast::constant_value_storage(array_value[index_value]);
 			}
-			case ast::constant_value_storage::uint_array:
+			case ast::constant_value_kind::uint_array:
 			{
 				auto const &array_value = value.get_uint_array();
 				bz_assert(index_value < array_value.size());
 				return ast::constant_value_storage(array_value[index_value]);
 			}
-			case ast::constant_value_storage::float32_array:
+			case ast::constant_value_kind::float32_array:
 			{
 				auto const &array_value = value.get_float32_array();
 				bz_assert(index_value < array_value.size());
 				return ast::constant_value_storage(array_value[index_value]);
 			}
-			case ast::constant_value_storage::float64_array:
+			case ast::constant_value_kind::float64_array:
 			{
 				auto const &array_value = value.get_float64_array();
 				bz_assert(index_value < array_value.size());
@@ -1695,7 +1695,7 @@ static ast::constant_value_storage evaluate_intrinsic_function_call(
 		else
 		{
 			auto result = ast::constant_value_storage();
-			auto &result_type = result.emplace<ast::constant_value_storage::type>();
+			auto &result_type = result.emplace<ast::constant_value_kind::type>();
 			result_type = ast::make_tuple_typespec(original_expr.src_tokens, {});
 			auto const &lhs_tuple_types = lhs_type.get<ast::ts_tuple>().types;
 			auto const &rhs_tuple_types = rhs_type.get<ast::ts_tuple>().types;
@@ -2018,26 +2018,26 @@ static ast::constant_value_storage get_default_constructed_value(
 		case ast::type_info::int16_:
 		case ast::type_info::int32_:
 		case ast::type_info::int64_:
-			result.emplace<ast::constant_value_storage::sint_array>(size, 0);
+			result.emplace<ast::constant_value_kind::sint_array>(size, 0);
 			break;
 		case ast::type_info::uint8_:
 		case ast::type_info::uint16_:
 		case ast::type_info::uint32_:
 		case ast::type_info::uint64_:
-			result.emplace<ast::constant_value_storage::uint_array>(size, 0);
+			result.emplace<ast::constant_value_kind::uint_array>(size, 0);
 			break;
 		case ast::type_info::float32_:
-			result.emplace<ast::constant_value_storage::float32_array>(size, 0.0f);
+			result.emplace<ast::constant_value_kind::float32_array>(size, 0.0f);
 			break;
 		case ast::type_info::float64_:
-			result.emplace<ast::constant_value_storage::float64_array>(size, 0.0);
+			result.emplace<ast::constant_value_kind::float64_array>(size, 0.0);
 			break;
 		default:
 		{
 			auto const elem_value = get_default_constructed_value(src_tokens, elem_type, context);
 			if (elem_value.not_null())
 			{
-				result.emplace<ast::constant_value_storage::array>(size, elem_value);
+				result.emplace<ast::constant_value_kind::array>(size, elem_value);
 			}
 			break;
 		}
@@ -2082,7 +2082,7 @@ static ast::constant_value_storage get_default_constructed_value(
 				else if (base_t.info->kind == ast::type_info::aggregate && base_t.info->default_constructor == nullptr)
 				{
 					ast::constant_value_storage result;
-					auto &elems = result.emplace<ast::constant_value_storage::aggregate>();
+					auto &elems = result.emplace<ast::constant_value_kind::aggregate>();
 					elems.reserve(base_t.info->member_variables.size());
 					for (auto const member : base_t.info->member_variables)
 					{
@@ -2105,7 +2105,7 @@ static ast::constant_value_storage get_default_constructed_value(
 			},
 			[&src_tokens, &context](ast::ts_tuple const &tuple_t) -> ast::constant_value_storage {
 				ast::constant_value_storage result;
-				auto &elems = result.emplace<ast::constant_value_storage::tuple>();
+				auto &elems = result.emplace<ast::constant_value_kind::tuple>();
 				elems.reserve(tuple_t.types.size());
 				for (auto const &type : tuple_t.types)
 				{
@@ -2178,7 +2178,7 @@ static ast::constant_value_storage evaluate_cast(
 		switch (value.kind())
 		{
 		static_assert(ast::constant_value_storage::variant_count == 19);
-		case ast::constant_value_storage::sint:
+		case ast::constant_value_kind::sint:
 		{
 			using T = std::tuple<bz::u8string_view, int64_t, int64_t, int64_t>;
 			auto const int_val = value.get_sint();
@@ -2197,7 +2197,7 @@ static ast::constant_value_storage evaluate_cast(
 			}
 			return ast::constant_value_storage(result);
 		}
-		case ast::constant_value_storage::uint:
+		case ast::constant_value_kind::uint:
 		{
 			using T = std::tuple<bz::u8string_view, int64_t, int64_t>;
 			auto const int_val = value.get_uint();
@@ -2216,7 +2216,7 @@ static ast::constant_value_storage evaluate_cast(
 			}
 			return ast::constant_value_storage(result);
 		}
-		case ast::constant_value_storage::float32:
+		case ast::constant_value_kind::float32:
 		{
 			auto const float_val = value.get_float32();
 			auto const result =
@@ -2226,7 +2226,7 @@ static ast::constant_value_storage evaluate_cast(
 				static_cast<int64_t>(float_val);
 			return ast::constant_value_storage(result);
 		}
-		case ast::constant_value_storage::float64:
+		case ast::constant_value_kind::float64:
 		{
 			auto const float_val = value.get_float64();
 			auto const result =
@@ -2236,10 +2236,10 @@ static ast::constant_value_storage evaluate_cast(
 				static_cast<int64_t>(float_val);
 			return ast::constant_value_storage(result);
 		}
-		case ast::constant_value_storage::u8char:
+		case ast::constant_value_kind::u8char:
 			// no overflow possible in constant expressions
 			return ast::constant_value_storage(static_cast<int64_t>(value.get_u8char()));
-		case ast::constant_value_storage::boolean:
+		case ast::constant_value_kind::boolean:
 			return ast::constant_value_storage(static_cast<int64_t>(value.get_boolean()));
 		default:
 			bz_unreachable;
@@ -2254,7 +2254,7 @@ static ast::constant_value_storage evaluate_cast(
 		switch (value.kind())
 		{
 		static_assert(ast::constant_value_storage::variant_count == 19);
-		case ast::constant_value_storage::sint:
+		case ast::constant_value_kind::sint:
 		{
 			using T = std::tuple<bz::u8string_view, uint64_t, uint64_t>;
 			auto const int_val = value.get_sint();
@@ -2273,7 +2273,7 @@ static ast::constant_value_storage evaluate_cast(
 			}
 			return ast::constant_value_storage(result);
 		}
-		case ast::constant_value_storage::uint:
+		case ast::constant_value_kind::uint:
 		{
 			using T = std::tuple<bz::u8string_view, uint64_t, uint64_t>;
 			auto const int_val = value.get_uint();
@@ -2292,7 +2292,7 @@ static ast::constant_value_storage evaluate_cast(
 			}
 			return ast::constant_value_storage(result);
 		}
-		case ast::constant_value_storage::float32:
+		case ast::constant_value_kind::float32:
 		{
 			auto const float_val = value.get_float32();
 			auto const result =
@@ -2302,7 +2302,7 @@ static ast::constant_value_storage evaluate_cast(
 				static_cast<uint64_t>(float_val);
 			return ast::constant_value_storage(result);
 		}
-		case ast::constant_value_storage::float64:
+		case ast::constant_value_kind::float64:
 		{
 			auto const float_val = value.get_float64();
 			auto const result =
@@ -2312,10 +2312,10 @@ static ast::constant_value_storage evaluate_cast(
 				static_cast<uint64_t>(float_val);
 			return ast::constant_value_storage(result);
 		}
-		case ast::constant_value_storage::u8char:
+		case ast::constant_value_kind::u8char:
 			// no overflow possible in constant expressions
 			return ast::constant_value_storage(static_cast<uint64_t>(value.get_u8char()));
-		case ast::constant_value_storage::boolean:
+		case ast::constant_value_kind::boolean:
 			return ast::constant_value_storage(static_cast<uint64_t>(value.get_boolean()));
 		default:
 			bz_unreachable;
@@ -2326,13 +2326,13 @@ static ast::constant_value_storage evaluate_cast(
 		switch (value.kind())
 		{
 		static_assert(ast::constant_value_storage::variant_count == 19);
-		case ast::constant_value_storage::sint:
+		case ast::constant_value_kind::sint:
 			return ast::constant_value_storage(static_cast<float32_t>(value.get_sint()));
-		case ast::constant_value_storage::uint:
+		case ast::constant_value_kind::uint:
 			return ast::constant_value_storage(static_cast<float32_t>(value.get_uint()));
-		case ast::constant_value_storage::float32:
+		case ast::constant_value_kind::float32:
 			return ast::constant_value_storage(static_cast<float32_t>(value.get_float32()));
-		case ast::constant_value_storage::float64:
+		case ast::constant_value_kind::float64:
 			return ast::constant_value_storage(static_cast<float32_t>(value.get_float64()));
 		default:
 			bz_unreachable;
@@ -2341,13 +2341,13 @@ static ast::constant_value_storage evaluate_cast(
 		switch (value.kind())
 		{
 		static_assert(ast::constant_value_storage::variant_count == 19);
-		case ast::constant_value_storage::sint:
+		case ast::constant_value_kind::sint:
 			return ast::constant_value_storage(static_cast<float64_t>(value.get_sint()));
-		case ast::constant_value_storage::uint:
+		case ast::constant_value_kind::uint:
 			return ast::constant_value_storage(static_cast<float64_t>(value.get_uint()));
-		case ast::constant_value_storage::float32:
+		case ast::constant_value_kind::float32:
 			return ast::constant_value_storage(static_cast<float64_t>(value.get_float32()));
-		case ast::constant_value_storage::float64:
+		case ast::constant_value_kind::float64:
 			return ast::constant_value_storage(static_cast<float64_t>(value.get_float64()));
 		default:
 			bz_unreachable;
@@ -2356,7 +2356,7 @@ static ast::constant_value_storage evaluate_cast(
 		switch (value.kind())
 		{
 		static_assert(ast::constant_value_storage::variant_count == 19);
-		case ast::constant_value_storage::sint:
+		case ast::constant_value_kind::sint:
 		{
 			auto const result = static_cast<bz::u8char>(value.get_sint());
 			if (!bz::is_valid_unicode_value(result))
@@ -2373,7 +2373,7 @@ static ast::constant_value_storage evaluate_cast(
 			}
 			return ast::constant_value_storage(result);
 		}
-		case ast::constant_value_storage::uint:
+		case ast::constant_value_kind::uint:
 		{
 			auto const result = static_cast<bz::u8char>(value.get_uint());
 			if (!bz::is_valid_unicode_value(result))
@@ -2402,7 +2402,7 @@ static ast::constant_value_storage evaluate_cast(
 	return {};
 }
 
-template<size_t value_kind, size_t value_array_kind, typename T>
+template<ast::constant_value_kind value_kind, ast::constant_value_kind value_array_kind, typename T>
 static bool consteval_guaranteed_special_array_value_helper(
 	ast::arena_vector<T> &values,
 	ast::typespec_view expr_type,
@@ -2487,12 +2487,12 @@ static ast::constant_value_storage consteval_guaranteed_special_array_value(
 	case ast::type_info::int64_:
 	{
 		auto result = ast::constant_value_storage();
-		auto &sint_array = result.emplace<ast::constant_value_storage::sint_array>();
+		auto &sint_array = result.emplace<ast::constant_value_kind::sint_array>();
 		sint_array.reserve(size);
 
 		auto const good = consteval_guaranteed_special_array_value_helper<
-			ast::constant_value_storage::sint,
-			ast::constant_value_storage::sint_array
+			ast::constant_value_kind::sint,
+			ast::constant_value_kind::sint_array
 		>(
 			sint_array,
 			array_type.get<ast::ts_array>().elem_type,
@@ -2512,12 +2512,12 @@ static ast::constant_value_storage consteval_guaranteed_special_array_value(
 	case ast::type_info::uint64_:
 	{
 		auto result = ast::constant_value_storage();
-		auto &uint_array = result.emplace<ast::constant_value_storage::uint_array>();
+		auto &uint_array = result.emplace<ast::constant_value_kind::uint_array>();
 		uint_array.reserve(size);
 
 		auto const good = consteval_guaranteed_special_array_value_helper<
-			ast::constant_value_storage::uint,
-			ast::constant_value_storage::uint_array
+			ast::constant_value_kind::uint,
+			ast::constant_value_kind::uint_array
 		>(
 			uint_array,
 			array_type.get<ast::ts_array>().elem_type,
@@ -2534,12 +2534,12 @@ static ast::constant_value_storage consteval_guaranteed_special_array_value(
 	case ast::type_info::float32_:
 	{
 		auto result = ast::constant_value_storage();
-		auto &float32_array = result.emplace<ast::constant_value_storage::float32_array>();
+		auto &float32_array = result.emplace<ast::constant_value_kind::float32_array>();
 		float32_array.reserve(size);
 
 		auto const good = consteval_guaranteed_special_array_value_helper<
-			ast::constant_value_storage::float32,
-			ast::constant_value_storage::float32_array
+			ast::constant_value_kind::float32,
+			ast::constant_value_kind::float32_array
 		>(
 			float32_array,
 			array_type.get<ast::ts_array>().elem_type,
@@ -2556,12 +2556,12 @@ static ast::constant_value_storage consteval_guaranteed_special_array_value(
 	case ast::type_info::float64_:
 	{
 		auto result = ast::constant_value_storage();
-		auto &float64_array = result.emplace<ast::constant_value_storage::float64_array>();
+		auto &float64_array = result.emplace<ast::constant_value_kind::float64_array>();
 		float64_array.reserve(size);
 
 		auto const good = consteval_guaranteed_special_array_value_helper<
-			ast::constant_value_storage::float64,
-			ast::constant_value_storage::float64_array
+			ast::constant_value_kind::float64,
+			ast::constant_value_kind::float64_array
 		>(
 			float64_array,
 			array_type.get<ast::ts_array>().elem_type,
@@ -2594,7 +2594,7 @@ static ast::constant_value_storage get_special_array_value(ast::typespec_view ar
 	case ast::type_info::int64_:
 	{
 		auto result = ast::constant_value_storage();
-		auto &sint_array = result.emplace<ast::constant_value_storage::sint_array>();
+		auto &sint_array = result.emplace<ast::constant_value_kind::sint_array>();
 		sint_array.reserve(size);
 		if (is_multi_dimensional)
 		{
@@ -2618,7 +2618,7 @@ static ast::constant_value_storage get_special_array_value(ast::typespec_view ar
 	case ast::type_info::uint64_:
 	{
 		auto result = ast::constant_value_storage();
-		auto &uint_array = result.emplace<ast::constant_value_storage::uint_array>();
+		auto &uint_array = result.emplace<ast::constant_value_kind::uint_array>();
 		uint_array.reserve(size);
 		if (is_multi_dimensional)
 		{
@@ -2639,7 +2639,7 @@ static ast::constant_value_storage get_special_array_value(ast::typespec_view ar
 	case ast::type_info::float32_:
 	{
 		auto result = ast::constant_value_storage();
-		auto &float32_array = result.emplace<ast::constant_value_storage::float32_array>();
+		auto &float32_array = result.emplace<ast::constant_value_kind::float32_array>();
 		float32_array.reserve(size);
 		if (is_multi_dimensional)
 		{
@@ -2660,7 +2660,7 @@ static ast::constant_value_storage get_special_array_value(ast::typespec_view ar
 	case ast::type_info::float64_:
 	{
 		auto result = ast::constant_value_storage();
-		auto &float64_array = result.emplace<ast::constant_value_storage::float64_array>();
+		auto &float64_array = result.emplace<ast::constant_value_kind::float64_array>();
 		float64_array.reserve(size);
 		if (is_multi_dimensional)
 		{
@@ -2911,7 +2911,7 @@ static ast::constant_value_storage guaranteed_evaluate_expr(
 			{
 				auto const [elem_type, size, is_multi_dimensional] = get_flattened_array_type_and_size(aggregate_init_expr.type);
 				auto result = ast::constant_value_storage();
-				auto &array = result.emplace<ast::constant_value_storage::array>();
+				auto &array = result.emplace<ast::constant_value_kind::array>();
 				array.reserve(size);
 				if (is_multi_dimensional)
 				{
@@ -2933,7 +2933,7 @@ static ast::constant_value_storage guaranteed_evaluate_expr(
 			else
 			{
 				auto result = ast::constant_value_storage();
-				auto &aggregate = result.emplace<ast::constant_value_storage::aggregate>();
+				auto &aggregate = result.emplace<ast::constant_value_kind::aggregate>();
 				aggregate.reserve(aggregate_init_expr.exprs.size());
 				for (auto const &expr : aggregate_init_expr.exprs)
 				{
@@ -2960,8 +2960,8 @@ static ast::constant_value_storage guaranteed_evaluate_expr(
 
 			ast::constant_value_storage result{};
 			auto &aggregate = aggregate_default_construct_expr.type.is<ast::ts_tuple>()
-				? result.emplace<ast::constant_value_storage::tuple>()
-				: result.emplace<ast::constant_value_storage::aggregate>();
+				? result.emplace<ast::constant_value_kind::tuple>()
+				: result.emplace<ast::constant_value_kind::aggregate>();
 			aggregate.reserve(aggregate_default_construct_expr.default_construct_exprs.size());
 			for (auto const &expr : aggregate_default_construct_expr.default_construct_exprs)
 			{
@@ -3010,11 +3010,11 @@ static ast::constant_value_storage guaranteed_evaluate_expr(
 				if (is_multi_dimensional)
 				{
 					bz_assert(value.is_array() && value.get_array().not_empty());
-					result.emplace<ast::constant_value_storage::array>(size, value.get_array()[0]);
+					result.emplace<ast::constant_value_kind::array>(size, value.get_array()[0]);
 				}
 				else
 				{
-					result.emplace<ast::constant_value_storage::array>(size, value);
+					result.emplace<ast::constant_value_kind::array>(size, value);
 				}
 				return result;
 			}

--- a/src/resolve/consteval.cpp
+++ b/src/resolve/consteval.cpp
@@ -57,7 +57,7 @@ bool is_special_array_type(ast::typespec_view type)
 	}
 }
 
-static ast::constant_value evaluate_binary_plus(
+static ast::constant_value_storage evaluate_binary_plus(
 	ast::expression const &original_expr,
 	ast::expression const &lhs, ast::expression const &rhs,
 	ctx::parse_context &context
@@ -76,39 +76,39 @@ static ast::constant_value evaluate_binary_plus(
 		auto const type = lhs_const_expr.type.remove_any_mut().get<ast::ts_base_type>().info->kind;
 		switch (lhs_value.kind())
 		{
-		static_assert(ast::constant_value::variant_count == 19);
-		case ast::constant_value::sint:
+		static_assert(ast::constant_value_storage::variant_count == 19);
+		case ast::constant_value_storage::sint:
 		{
 			auto const lhs_int_val = lhs_value.get_sint();
 			auto const rhs_int_val = rhs_value.get_sint();
-			return ast::constant_value(safe_binary_plus(
+			return ast::constant_value_storage(safe_binary_plus(
 				original_expr.src_tokens, original_expr.paren_level,
 				lhs_int_val, rhs_int_val, type, context
 			));
 		}
-		case ast::constant_value::uint:
+		case ast::constant_value_storage::uint:
 		{
 			auto const lhs_int_val = lhs_value.get_uint();
 			auto const rhs_int_val = rhs_value.get_uint();
-			return ast::constant_value(safe_binary_plus(
+			return ast::constant_value_storage(safe_binary_plus(
 				original_expr.src_tokens, original_expr.paren_level,
 				lhs_int_val, rhs_int_val, type, context
 			));
 		}
-		case ast::constant_value::float32:
+		case ast::constant_value_storage::float32:
 		{
 			auto const lhs_float_val = lhs_value.get_float32();
 			auto const rhs_float_val = rhs_value.get_float32();
-			return ast::constant_value(safe_binary_plus(
+			return ast::constant_value_storage(safe_binary_plus(
 				original_expr.src_tokens, original_expr.paren_level,
 				lhs_float_val, rhs_float_val, context
 			));
 		}
-		case ast::constant_value::float64:
+		case ast::constant_value_storage::float64:
 		{
 			auto const lhs_float_val = lhs_value.get_float64();
 			auto const rhs_float_val = rhs_value.get_float64();
-			return ast::constant_value(safe_binary_plus(
+			return ast::constant_value_storage(safe_binary_plus(
 				original_expr.src_tokens, original_expr.paren_level,
 				lhs_float_val, rhs_float_val, context
 			));
@@ -134,7 +134,7 @@ static ast::constant_value evaluate_binary_plus(
 			);
 		if (result.has_value())
 		{
-			return ast::constant_value(result.get());
+			return ast::constant_value_storage(result.get());
 		}
 		else
 		{
@@ -159,7 +159,7 @@ static ast::constant_value evaluate_binary_plus(
 			);
 		if (result.has_value())
 		{
-			return ast::constant_value(result.get());
+			return ast::constant_value_storage(result.get());
 		}
 		else
 		{
@@ -168,7 +168,7 @@ static ast::constant_value evaluate_binary_plus(
 	}
 }
 
-static ast::constant_value evaluate_binary_minus(
+static ast::constant_value_storage evaluate_binary_minus(
 	ast::expression const &original_expr,
 	ast::expression const &lhs, ast::expression const &rhs,
 	ctx::parse_context &context
@@ -187,45 +187,45 @@ static ast::constant_value evaluate_binary_minus(
 		auto const type = lhs_const_expr.type.remove_any_mut().get<ast::ts_base_type>().info->kind;
 		switch (lhs_value.kind())
 		{
-		static_assert(ast::constant_value::variant_count == 19);
-		case ast::constant_value::sint:
+		static_assert(ast::constant_value_storage::variant_count == 19);
+		case ast::constant_value_storage::sint:
 		{
 			auto const lhs_int_val = lhs_value.get_sint();
 			auto const rhs_int_val = rhs_value.get_sint();
-			return ast::constant_value(safe_binary_minus(
+			return ast::constant_value_storage(safe_binary_minus(
 				original_expr.src_tokens, original_expr.paren_level,
 				lhs_int_val, rhs_int_val, type, context
 			));
 		}
-		case ast::constant_value::uint:
+		case ast::constant_value_storage::uint:
 		{
 			auto const lhs_int_val = lhs_value.get_uint();
 			auto const rhs_int_val = rhs_value.get_uint();
-			return ast::constant_value(safe_binary_minus(
+			return ast::constant_value_storage(safe_binary_minus(
 				original_expr.src_tokens, original_expr.paren_level,
 				lhs_int_val, rhs_int_val, type, context
 			));
 		}
-		case ast::constant_value::float32:
+		case ast::constant_value_storage::float32:
 		{
 			auto const lhs_float_val = lhs_value.get_float32();
 			auto const rhs_float_val = rhs_value.get_float32();
-			return ast::constant_value(safe_binary_minus(
+			return ast::constant_value_storage(safe_binary_minus(
 				original_expr.src_tokens, original_expr.paren_level,
 				lhs_float_val, rhs_float_val, context
 			));
 		}
-		case ast::constant_value::float64:
+		case ast::constant_value_storage::float64:
 		{
 			auto const lhs_float_val = lhs_value.get_float64();
 			auto const rhs_float_val = rhs_value.get_float64();
-			return ast::constant_value(safe_binary_minus(
+			return ast::constant_value_storage(safe_binary_minus(
 				original_expr.src_tokens, original_expr.paren_level,
 				lhs_float_val, rhs_float_val, context
 			));
 		}
-		case ast::constant_value::u8char:
-			return ast::constant_value(
+		case ast::constant_value_storage::u8char:
+			return ast::constant_value_storage(
 				static_cast<int64_t>(lhs_value.get_u8char())
 				- static_cast<int64_t>(rhs_value.get_u8char())
 			);
@@ -251,7 +251,7 @@ static ast::constant_value evaluate_binary_minus(
 			);
 		if (result.has_value())
 		{
-			return ast::constant_value(result.get());
+			return ast::constant_value_storage(result.get());
 		}
 		else
 		{
@@ -260,7 +260,7 @@ static ast::constant_value evaluate_binary_minus(
 	}
 }
 
-static ast::constant_value evaluate_binary_multiply(
+static ast::constant_value_storage evaluate_binary_multiply(
 	ast::expression const &original_expr,
 	ast::expression const &lhs, ast::expression const &rhs,
 	ctx::parse_context &context
@@ -278,39 +278,39 @@ static ast::constant_value evaluate_binary_multiply(
 	auto const type = lhs_const_expr.type.remove_any_mut().get<ast::ts_base_type>().info->kind;
 	switch (lhs_value.kind())
 	{
-	static_assert(ast::constant_value::variant_count == 19);
-	case ast::constant_value::sint:
+	static_assert(ast::constant_value_storage::variant_count == 19);
+	case ast::constant_value_storage::sint:
 	{
 		auto const lhs_int_val = lhs_value.get_sint();
 		auto const rhs_int_val = rhs_value.get_sint();
-		return ast::constant_value(safe_binary_multiply(
+		return ast::constant_value_storage(safe_binary_multiply(
 			original_expr.src_tokens, original_expr.paren_level,
 			lhs_int_val, rhs_int_val, type, context
 		));
 	}
-	case ast::constant_value::uint:
+	case ast::constant_value_storage::uint:
 	{
 		auto const lhs_int_val = lhs_value.get_uint();
 		auto const rhs_int_val = rhs_value.get_uint();
-		return ast::constant_value(safe_binary_multiply(
+		return ast::constant_value_storage(safe_binary_multiply(
 			original_expr.src_tokens, original_expr.paren_level,
 			lhs_int_val, rhs_int_val, type, context
 		));
 	}
-	case ast::constant_value::float32:
+	case ast::constant_value_storage::float32:
 	{
 		auto const lhs_float_val = lhs_value.get_float32();
 		auto const rhs_float_val = rhs_value.get_float32();
-		return ast::constant_value(safe_binary_multiply(
+		return ast::constant_value_storage(safe_binary_multiply(
 			original_expr.src_tokens, original_expr.paren_level,
 			lhs_float_val, rhs_float_val, context
 		));
 	}
-	case ast::constant_value::float64:
+	case ast::constant_value_storage::float64:
 	{
 		auto const lhs_float_val = lhs_value.get_float64();
 		auto const rhs_float_val = rhs_value.get_float64();
-		return ast::constant_value(safe_binary_multiply(
+		return ast::constant_value_storage(safe_binary_multiply(
 			original_expr.src_tokens, original_expr.paren_level,
 			lhs_float_val, rhs_float_val, context
 		));
@@ -320,7 +320,7 @@ static ast::constant_value evaluate_binary_multiply(
 	}
 }
 
-static ast::constant_value evaluate_binary_divide(
+static ast::constant_value_storage evaluate_binary_divide(
 	ast::expression const &original_expr,
 	ast::expression const &lhs, ast::expression const &rhs,
 	ctx::parse_context &context
@@ -338,8 +338,8 @@ static ast::constant_value evaluate_binary_divide(
 	auto const type = lhs_const_expr.type.remove_any_mut().get<ast::ts_base_type>().info->kind;
 	switch (lhs_value.kind())
 	{
-	static_assert(ast::constant_value::variant_count == 19);
-	case ast::constant_value::sint:
+	static_assert(ast::constant_value_storage::variant_count == 19);
+	case ast::constant_value_storage::sint:
 	{
 		auto const lhs_int_val = lhs_value.get_sint();
 		auto const rhs_int_val = rhs_value.get_sint();
@@ -349,14 +349,14 @@ static ast::constant_value evaluate_binary_divide(
 		);
 		if (result.has_value())
 		{
-			return ast::constant_value(result.get());
+			return ast::constant_value_storage(result.get());
 		}
 		else
 		{
 			return {};
 		}
 	}
-	case ast::constant_value::uint:
+	case ast::constant_value_storage::uint:
 	{
 		auto const lhs_int_val = lhs_value.get_uint();
 		auto const rhs_int_val = rhs_value.get_uint();
@@ -366,27 +366,27 @@ static ast::constant_value evaluate_binary_divide(
 		);
 		if (result.has_value())
 		{
-			return ast::constant_value(result.get());
+			return ast::constant_value_storage(result.get());
 		}
 		else
 		{
 			return {};
 		}
 	}
-	case ast::constant_value::float32:
+	case ast::constant_value_storage::float32:
 	{
 		auto const lhs_float_val = lhs_value.get_float32();
 		auto const rhs_float_val = rhs_value.get_float32();
-		return ast::constant_value(safe_binary_divide(
+		return ast::constant_value_storage(safe_binary_divide(
 			original_expr.src_tokens, original_expr.paren_level,
 			lhs_float_val, rhs_float_val, context
 		));
 	}
-	case ast::constant_value::float64:
+	case ast::constant_value_storage::float64:
 	{
 		auto const lhs_float_val = lhs_value.get_float64();
 		auto const rhs_float_val = rhs_value.get_float64();
-		return ast::constant_value(safe_binary_divide(
+		return ast::constant_value_storage(safe_binary_divide(
 			original_expr.src_tokens, original_expr.paren_level,
 			lhs_float_val, rhs_float_val, context
 		));
@@ -396,7 +396,7 @@ static ast::constant_value evaluate_binary_divide(
 	}
 }
 
-static ast::constant_value evaluate_binary_modulo(
+static ast::constant_value_storage evaluate_binary_modulo(
 	ast::expression const &original_expr,
 	ast::expression const &lhs, ast::expression const &rhs,
 	ctx::parse_context &context
@@ -414,8 +414,8 @@ static ast::constant_value evaluate_binary_modulo(
 	auto const type = lhs_const_expr.type.remove_any_mut().get<ast::ts_base_type>().info->kind;
 	switch (lhs_value.kind())
 	{
-	static_assert(ast::constant_value::variant_count == 19);
-	case ast::constant_value::sint:
+	static_assert(ast::constant_value_storage::variant_count == 19);
+	case ast::constant_value_storage::sint:
 	{
 		auto const lhs_int_val = lhs_value.get_sint();
 		auto const rhs_int_val = rhs_value.get_sint();
@@ -425,14 +425,14 @@ static ast::constant_value evaluate_binary_modulo(
 		);
 		if (result.has_value())
 		{
-			return ast::constant_value(result.get());
+			return ast::constant_value_storage(result.get());
 		}
 		else
 		{
 			return {};
 		}
 	}
-	case ast::constant_value::uint:
+	case ast::constant_value_storage::uint:
 	{
 		auto const lhs_int_val = lhs_value.get_uint();
 		auto const rhs_int_val = rhs_value.get_uint();
@@ -442,7 +442,7 @@ static ast::constant_value evaluate_binary_modulo(
 		);
 		if (result.has_value())
 		{
-			return ast::constant_value(result.get());
+			return ast::constant_value_storage(result.get());
 		}
 		else
 		{
@@ -454,7 +454,7 @@ static ast::constant_value evaluate_binary_modulo(
 	}
 }
 
-static ast::constant_value evaluate_binary_equals(
+static ast::constant_value_storage evaluate_binary_equals(
 	[[maybe_unused]] ast::expression const &original_expr,
 	ast::expression const &lhs, ast::expression const &rhs,
 	[[maybe_unused]] ctx::parse_context &context
@@ -471,71 +471,71 @@ static ast::constant_value evaluate_binary_equals(
 
 	switch (lhs_value.kind())
 	{
-	static_assert(ast::constant_value::variant_count == 19);
-	case ast::constant_value::sint:
+	static_assert(ast::constant_value_storage::variant_count == 19);
+	case ast::constant_value_storage::sint:
 	{
 		auto const lhs_int_val = lhs_value.get_sint();
 		auto const rhs_int_val = rhs_value.get_sint();
-		return ast::constant_value(lhs_int_val == rhs_int_val);
+		return ast::constant_value_storage(lhs_int_val == rhs_int_val);
 	}
-	case ast::constant_value::uint:
+	case ast::constant_value_storage::uint:
 	{
 		auto const lhs_int_val = lhs_value.get_uint();
 		auto const rhs_int_val = rhs_value.get_uint();
-		return ast::constant_value(lhs_int_val == rhs_int_val);
+		return ast::constant_value_storage(lhs_int_val == rhs_int_val);
 	}
-	case ast::constant_value::float32:
+	case ast::constant_value_storage::float32:
 	{
 		auto const lhs_float_val = lhs_value.get_float32();
 		auto const rhs_float_val = rhs_value.get_float32();
-		return ast::constant_value(safe_binary_equals(
+		return ast::constant_value_storage(safe_binary_equals(
 			original_expr.src_tokens, original_expr.paren_level,
 			lhs_float_val, rhs_float_val, context
 		));
 	}
-	case ast::constant_value::float64:
+	case ast::constant_value_storage::float64:
 	{
 		auto const lhs_float_val = lhs_value.get_float64();
 		auto const rhs_float_val = rhs_value.get_float64();
-		return ast::constant_value(safe_binary_equals(
+		return ast::constant_value_storage(safe_binary_equals(
 			original_expr.src_tokens, original_expr.paren_level,
 			lhs_float_val, rhs_float_val, context
 		));
 	}
-	case ast::constant_value::u8char:
+	case ast::constant_value_storage::u8char:
 	{
 		auto const lhs_char_val = lhs_value.get_u8char();
 		auto const rhs_char_val = rhs_value.get_u8char();
-		return ast::constant_value(lhs_char_val == rhs_char_val);
+		return ast::constant_value_storage(lhs_char_val == rhs_char_val);
 	}
-	case ast::constant_value::boolean:
+	case ast::constant_value_storage::boolean:
 	{
 		auto const lhs_bool_val = lhs_value.get_boolean();
 		auto const rhs_bool_val = rhs_value.get_boolean();
-		return ast::constant_value(lhs_bool_val == rhs_bool_val);
+		return ast::constant_value_storage(lhs_bool_val == rhs_bool_val);
 	}
-	case ast::constant_value::string:
+	case ast::constant_value_storage::string:
 	{
 		auto const lhs_str_val = lhs_value.get_string();
 		auto const rhs_str_val = rhs_value.get_string();
-		return ast::constant_value(lhs_str_val == rhs_str_val);
+		return ast::constant_value_storage(lhs_str_val == rhs_str_val);
 	}
-	case ast::constant_value::null:
+	case ast::constant_value_storage::null:
 	{
-		return ast::constant_value(true);
+		return ast::constant_value_storage(true);
 	}
-	case ast::constant_value::enum_:
+	case ast::constant_value_storage::enum_:
 	{
 		auto const lhs_enum_value = lhs_value.get_enum().value;
 		auto const rhs_enum_value = rhs_value.get_enum().value;
-		return ast::constant_value(lhs_enum_value == rhs_enum_value);
+		return ast::constant_value_storage(lhs_enum_value == rhs_enum_value);
 	}
 	default:
 		bz_unreachable;
 	}
 }
 
-static ast::constant_value evaluate_binary_not_equals(
+static ast::constant_value_storage evaluate_binary_not_equals(
 	[[maybe_unused]] ast::expression const &original_expr,
 	ast::expression const &lhs, ast::expression const &rhs,
 	[[maybe_unused]] ctx::parse_context &context
@@ -552,65 +552,65 @@ static ast::constant_value evaluate_binary_not_equals(
 
 	switch (lhs_value.kind())
 	{
-	static_assert(ast::constant_value::variant_count == 19);
-	case ast::constant_value::sint:
+	static_assert(ast::constant_value_storage::variant_count == 19);
+	case ast::constant_value_storage::sint:
 	{
 		auto const lhs_int_val = lhs_value.get_sint();
 		auto const rhs_int_val = rhs_value.get_sint();
-		return ast::constant_value(lhs_int_val != rhs_int_val);
+		return ast::constant_value_storage(lhs_int_val != rhs_int_val);
 	}
-	case ast::constant_value::uint:
+	case ast::constant_value_storage::uint:
 	{
 		auto const lhs_int_val = lhs_value.get_uint();
 		auto const rhs_int_val = rhs_value.get_uint();
-		return ast::constant_value(lhs_int_val != rhs_int_val);
+		return ast::constant_value_storage(lhs_int_val != rhs_int_val);
 	}
-	case ast::constant_value::float32:
+	case ast::constant_value_storage::float32:
 	{
 		auto const lhs_float_val = lhs_value.get_float32();
 		auto const rhs_float_val = rhs_value.get_float32();
-		return ast::constant_value(lhs_float_val != rhs_float_val);
+		return ast::constant_value_storage(lhs_float_val != rhs_float_val);
 	}
-	case ast::constant_value::float64:
+	case ast::constant_value_storage::float64:
 	{
 		auto const lhs_float_val = lhs_value.get_float64();
 		auto const rhs_float_val = rhs_value.get_float64();
-		return ast::constant_value(lhs_float_val != rhs_float_val);
+		return ast::constant_value_storage(lhs_float_val != rhs_float_val);
 	}
-	case ast::constant_value::u8char:
+	case ast::constant_value_storage::u8char:
 	{
 		auto const lhs_char_val = lhs_value.get_u8char();
 		auto const rhs_char_val = rhs_value.get_u8char();
-		return ast::constant_value(lhs_char_val != rhs_char_val);
+		return ast::constant_value_storage(lhs_char_val != rhs_char_val);
 	}
-	case ast::constant_value::boolean:
+	case ast::constant_value_storage::boolean:
 	{
 		auto const lhs_bool_val = lhs_value.get_boolean();
 		auto const rhs_bool_val = rhs_value.get_boolean();
-		return ast::constant_value(lhs_bool_val != rhs_bool_val);
+		return ast::constant_value_storage(lhs_bool_val != rhs_bool_val);
 	}
-	case ast::constant_value::string:
+	case ast::constant_value_storage::string:
 	{
 		auto const lhs_str_val = lhs_value.get_string();
 		auto const rhs_str_val = rhs_value.get_string();
-		return ast::constant_value(lhs_str_val != rhs_str_val);
+		return ast::constant_value_storage(lhs_str_val != rhs_str_val);
 	}
-	case ast::constant_value::null:
+	case ast::constant_value_storage::null:
 	{
-		return ast::constant_value(false);
+		return ast::constant_value_storage(false);
 	}
-	case ast::constant_value::enum_:
+	case ast::constant_value_storage::enum_:
 	{
 		auto const lhs_enum_value = lhs_value.get_enum().value;
 		auto const rhs_enum_value = rhs_value.get_enum().value;
-		return ast::constant_value(lhs_enum_value != rhs_enum_value);
+		return ast::constant_value_storage(lhs_enum_value != rhs_enum_value);
 	}
 	default:
 		bz_unreachable;
 	}
 }
 
-static ast::constant_value evaluate_binary_less_than(
+static ast::constant_value_storage evaluate_binary_less_than(
 	[[maybe_unused]] ast::expression const &original_expr,
 	ast::expression const &lhs, ast::expression const &rhs,
 	[[maybe_unused]] ctx::parse_context &context
@@ -627,56 +627,56 @@ static ast::constant_value evaluate_binary_less_than(
 
 	switch (lhs_value.kind())
 	{
-	static_assert(ast::constant_value::variant_count == 19);
-	case ast::constant_value::sint:
+	static_assert(ast::constant_value_storage::variant_count == 19);
+	case ast::constant_value_storage::sint:
 	{
 		auto const lhs_int_val = lhs_value.get_sint();
 		auto const rhs_int_val = rhs_value.get_sint();
-		return ast::constant_value(lhs_int_val < rhs_int_val);
+		return ast::constant_value_storage(lhs_int_val < rhs_int_val);
 	}
-	case ast::constant_value::uint:
+	case ast::constant_value_storage::uint:
 	{
 		auto const lhs_int_val = lhs_value.get_uint();
 		auto const rhs_int_val = rhs_value.get_uint();
-		return ast::constant_value(lhs_int_val < rhs_int_val);
+		return ast::constant_value_storage(lhs_int_val < rhs_int_val);
 	}
-	case ast::constant_value::float32:
+	case ast::constant_value_storage::float32:
 	{
 		auto const lhs_float_val = lhs_value.get_float32();
 		auto const rhs_float_val = rhs_value.get_float32();
-		return ast::constant_value(lhs_float_val < rhs_float_val);
+		return ast::constant_value_storage(lhs_float_val < rhs_float_val);
 	}
-	case ast::constant_value::float64:
+	case ast::constant_value_storage::float64:
 	{
 		auto const lhs_float_val = lhs_value.get_float64();
 		auto const rhs_float_val = rhs_value.get_float64();
-		return ast::constant_value(lhs_float_val < rhs_float_val);
+		return ast::constant_value_storage(lhs_float_val < rhs_float_val);
 	}
-	case ast::constant_value::u8char:
+	case ast::constant_value_storage::u8char:
 	{
 		auto const lhs_char_val = lhs_value.get_u8char();
 		auto const rhs_char_val = rhs_value.get_u8char();
-		return ast::constant_value(lhs_char_val < rhs_char_val);
+		return ast::constant_value_storage(lhs_char_val < rhs_char_val);
 	}
-	case ast::constant_value::null:
+	case ast::constant_value_storage::null:
 	{
-		return ast::constant_value(false);
+		return ast::constant_value_storage(false);
 	}
-	case ast::constant_value::enum_:
+	case ast::constant_value_storage::enum_:
 	{
 		auto const [decl, lhs_enum_value] = lhs_value.get_enum();
 		auto const rhs_enum_value = rhs_value.get_enum().value;
 		auto const is_signed = ast::is_signed_integer_kind(decl->underlying_type.get<ast::ts_base_type>().info->kind);
 		return is_signed
-			? ast::constant_value(bit_cast<int64_t>(lhs_enum_value) < bit_cast<int64_t>(rhs_enum_value))
-			: ast::constant_value(lhs_enum_value < rhs_enum_value);
+			? ast::constant_value_storage(bit_cast<int64_t>(lhs_enum_value) < bit_cast<int64_t>(rhs_enum_value))
+			: ast::constant_value_storage(lhs_enum_value < rhs_enum_value);
 	}
 	default:
 		bz_unreachable;
 	}
 }
 
-static ast::constant_value evaluate_binary_less_than_eq(
+static ast::constant_value_storage evaluate_binary_less_than_eq(
 	[[maybe_unused]] ast::expression const &original_expr,
 	ast::expression const &lhs, ast::expression const &rhs,
 	[[maybe_unused]] ctx::parse_context &context
@@ -693,56 +693,56 @@ static ast::constant_value evaluate_binary_less_than_eq(
 
 	switch (lhs_value.kind())
 	{
-	static_assert(ast::constant_value::variant_count == 19);
-	case ast::constant_value::sint:
+	static_assert(ast::constant_value_storage::variant_count == 19);
+	case ast::constant_value_storage::sint:
 	{
 		auto const lhs_int_val = lhs_value.get_sint();
 		auto const rhs_int_val = rhs_value.get_sint();
-		return ast::constant_value(lhs_int_val <= rhs_int_val);
+		return ast::constant_value_storage(lhs_int_val <= rhs_int_val);
 	}
-	case ast::constant_value::uint:
+	case ast::constant_value_storage::uint:
 	{
 		auto const lhs_int_val = lhs_value.get_uint();
 		auto const rhs_int_val = rhs_value.get_uint();
-		return ast::constant_value(lhs_int_val <= rhs_int_val);
+		return ast::constant_value_storage(lhs_int_val <= rhs_int_val);
 	}
-	case ast::constant_value::float32:
+	case ast::constant_value_storage::float32:
 	{
 		auto const lhs_float_val = lhs_value.get_float32();
 		auto const rhs_float_val = rhs_value.get_float32();
-		return ast::constant_value(lhs_float_val <= rhs_float_val);
+		return ast::constant_value_storage(lhs_float_val <= rhs_float_val);
 	}
-	case ast::constant_value::float64:
+	case ast::constant_value_storage::float64:
 	{
 		auto const lhs_float_val = lhs_value.get_float64();
 		auto const rhs_float_val = rhs_value.get_float64();
-		return ast::constant_value(lhs_float_val <= rhs_float_val);
+		return ast::constant_value_storage(lhs_float_val <= rhs_float_val);
 	}
-	case ast::constant_value::u8char:
+	case ast::constant_value_storage::u8char:
 	{
 		auto const lhs_char_val = lhs_value.get_u8char();
 		auto const rhs_char_val = rhs_value.get_u8char();
-		return ast::constant_value(lhs_char_val <= rhs_char_val);
+		return ast::constant_value_storage(lhs_char_val <= rhs_char_val);
 	}
-	case ast::constant_value::null:
+	case ast::constant_value_storage::null:
 	{
-		return ast::constant_value(true);
+		return ast::constant_value_storage(true);
 	}
-	case ast::constant_value::enum_:
+	case ast::constant_value_storage::enum_:
 	{
 		auto const [decl, lhs_enum_value] = lhs_value.get_enum();
 		auto const rhs_enum_value = rhs_value.get_enum().value;
 		auto const is_signed = ast::is_signed_integer_kind(decl->underlying_type.get<ast::ts_base_type>().info->kind);
 		return is_signed
-			? ast::constant_value(bit_cast<int64_t>(lhs_enum_value) <= bit_cast<int64_t>(rhs_enum_value))
-			: ast::constant_value(lhs_enum_value <= rhs_enum_value);
+			? ast::constant_value_storage(bit_cast<int64_t>(lhs_enum_value) <= bit_cast<int64_t>(rhs_enum_value))
+			: ast::constant_value_storage(lhs_enum_value <= rhs_enum_value);
 	}
 	default:
 		bz_unreachable;
 	}
 }
 
-static ast::constant_value evaluate_binary_greater_than(
+static ast::constant_value_storage evaluate_binary_greater_than(
 	[[maybe_unused]] ast::expression const &original_expr,
 	ast::expression const &lhs, ast::expression const &rhs,
 	[[maybe_unused]] ctx::parse_context &context
@@ -759,56 +759,56 @@ static ast::constant_value evaluate_binary_greater_than(
 
 	switch (lhs_value.kind())
 	{
-	static_assert(ast::constant_value::variant_count == 19);
-	case ast::constant_value::sint:
+	static_assert(ast::constant_value_storage::variant_count == 19);
+	case ast::constant_value_storage::sint:
 	{
 		auto const lhs_int_val = lhs_value.get_sint();
 		auto const rhs_int_val = rhs_value.get_sint();
-		return ast::constant_value(lhs_int_val > rhs_int_val);
+		return ast::constant_value_storage(lhs_int_val > rhs_int_val);
 	}
-	case ast::constant_value::uint:
+	case ast::constant_value_storage::uint:
 	{
 		auto const lhs_int_val = lhs_value.get_uint();
 		auto const rhs_int_val = rhs_value.get_uint();
-		return ast::constant_value(lhs_int_val > rhs_int_val);
+		return ast::constant_value_storage(lhs_int_val > rhs_int_val);
 	}
-	case ast::constant_value::float32:
+	case ast::constant_value_storage::float32:
 	{
 		auto const lhs_float_val = lhs_value.get_float32();
 		auto const rhs_float_val = rhs_value.get_float32();
-		return ast::constant_value(lhs_float_val > rhs_float_val);
+		return ast::constant_value_storage(lhs_float_val > rhs_float_val);
 	}
-	case ast::constant_value::float64:
+	case ast::constant_value_storage::float64:
 	{
 		auto const lhs_float_val = lhs_value.get_float64();
 		auto const rhs_float_val = rhs_value.get_float64();
-		return ast::constant_value(lhs_float_val > rhs_float_val);
+		return ast::constant_value_storage(lhs_float_val > rhs_float_val);
 	}
-	case ast::constant_value::u8char:
+	case ast::constant_value_storage::u8char:
 	{
 		auto const lhs_char_val = lhs_value.get_u8char();
 		auto const rhs_char_val = rhs_value.get_u8char();
-		return ast::constant_value(lhs_char_val > rhs_char_val);
+		return ast::constant_value_storage(lhs_char_val > rhs_char_val);
 	}
-	case ast::constant_value::null:
+	case ast::constant_value_storage::null:
 	{
-		return ast::constant_value(false);
+		return ast::constant_value_storage(false);
 	}
-	case ast::constant_value::enum_:
+	case ast::constant_value_storage::enum_:
 	{
 		auto const [decl, lhs_enum_value] = lhs_value.get_enum();
 		auto const rhs_enum_value = rhs_value.get_enum().value;
 		auto const is_signed = ast::is_signed_integer_kind(decl->underlying_type.get<ast::ts_base_type>().info->kind);
 		return is_signed
-			? ast::constant_value(bit_cast<int64_t>(lhs_enum_value) > bit_cast<int64_t>(rhs_enum_value))
-			: ast::constant_value(lhs_enum_value > rhs_enum_value);
+			? ast::constant_value_storage(bit_cast<int64_t>(lhs_enum_value) > bit_cast<int64_t>(rhs_enum_value))
+			: ast::constant_value_storage(lhs_enum_value > rhs_enum_value);
 	}
 	default:
 		bz_unreachable;
 	}
 }
 
-static ast::constant_value evaluate_binary_greater_than_eq(
+static ast::constant_value_storage evaluate_binary_greater_than_eq(
 	[[maybe_unused]] ast::expression const &original_expr,
 	ast::expression const &lhs, ast::expression const &rhs,
 	[[maybe_unused]] ctx::parse_context &context
@@ -825,56 +825,56 @@ static ast::constant_value evaluate_binary_greater_than_eq(
 
 	switch (lhs_value.kind())
 	{
-	static_assert(ast::constant_value::variant_count == 19);
-	case ast::constant_value::sint:
+	static_assert(ast::constant_value_storage::variant_count == 19);
+	case ast::constant_value_storage::sint:
 	{
 		auto const lhs_int_val = lhs_value.get_sint();
 		auto const rhs_int_val = rhs_value.get_sint();
-		return ast::constant_value(lhs_int_val >= rhs_int_val);
+		return ast::constant_value_storage(lhs_int_val >= rhs_int_val);
 	}
-	case ast::constant_value::uint:
+	case ast::constant_value_storage::uint:
 	{
 		auto const lhs_int_val = lhs_value.get_uint();
 		auto const rhs_int_val = rhs_value.get_uint();
-		return ast::constant_value(lhs_int_val >= rhs_int_val);
+		return ast::constant_value_storage(lhs_int_val >= rhs_int_val);
 	}
-	case ast::constant_value::float32:
+	case ast::constant_value_storage::float32:
 	{
 		auto const lhs_float_val = lhs_value.get_float32();
 		auto const rhs_float_val = rhs_value.get_float32();
-		return ast::constant_value(lhs_float_val >= rhs_float_val);
+		return ast::constant_value_storage(lhs_float_val >= rhs_float_val);
 	}
-	case ast::constant_value::float64:
+	case ast::constant_value_storage::float64:
 	{
 		auto const lhs_float_val = lhs_value.get_float64();
 		auto const rhs_float_val = rhs_value.get_float64();
-		return ast::constant_value(lhs_float_val >= rhs_float_val);
+		return ast::constant_value_storage(lhs_float_val >= rhs_float_val);
 	}
-	case ast::constant_value::u8char:
+	case ast::constant_value_storage::u8char:
 	{
 		auto const lhs_char_val = lhs_value.get_u8char();
 		auto const rhs_char_val = rhs_value.get_u8char();
-		return ast::constant_value(lhs_char_val >= rhs_char_val);
+		return ast::constant_value_storage(lhs_char_val >= rhs_char_val);
 	}
-	case ast::constant_value::null:
+	case ast::constant_value_storage::null:
 	{
-		return ast::constant_value(true);
+		return ast::constant_value_storage(true);
 	}
-	case ast::constant_value::enum_:
+	case ast::constant_value_storage::enum_:
 	{
 		auto const [decl, lhs_enum_value] = lhs_value.get_enum();
 		auto const rhs_enum_value = rhs_value.get_enum().value;
 		auto const is_signed = ast::is_signed_integer_kind(decl->underlying_type.get<ast::ts_base_type>().info->kind);
 		return is_signed
-			? ast::constant_value(bit_cast<int64_t>(lhs_enum_value) >= bit_cast<int64_t>(rhs_enum_value))
-			: ast::constant_value(lhs_enum_value >= rhs_enum_value);
+			? ast::constant_value_storage(bit_cast<int64_t>(lhs_enum_value) >= bit_cast<int64_t>(rhs_enum_value))
+			: ast::constant_value_storage(lhs_enum_value >= rhs_enum_value);
 	}
 	default:
 		bz_unreachable;
 	}
 }
 
-static ast::constant_value evaluate_binary_bit_and(
+static ast::constant_value_storage evaluate_binary_bit_and(
 	[[maybe_unused]] ast::expression const &original_expr,
 	ast::expression const &lhs, ast::expression const &rhs,
 	[[maybe_unused]] ctx::parse_context &context
@@ -891,25 +891,25 @@ static ast::constant_value evaluate_binary_bit_and(
 
 	switch (lhs_value.kind())
 	{
-	static_assert(ast::constant_value::variant_count == 19);
-	case ast::constant_value::uint:
+	static_assert(ast::constant_value_storage::variant_count == 19);
+	case ast::constant_value_storage::uint:
 	{
 		auto const lhs_int_val = lhs_value.get_uint();
 		auto const rhs_int_val = rhs_value.get_uint();
-		return ast::constant_value(lhs_int_val & rhs_int_val);
+		return ast::constant_value_storage(lhs_int_val & rhs_int_val);
 	}
-	case ast::constant_value::boolean:
+	case ast::constant_value_storage::boolean:
 	{
 		auto const lhs_bool_val = lhs_value.get_boolean();
 		auto const rhs_bool_val = rhs_value.get_boolean();
-		return ast::constant_value(lhs_bool_val && rhs_bool_val);
+		return ast::constant_value_storage(lhs_bool_val && rhs_bool_val);
 	}
 	default:
 		bz_unreachable;
 	}
 }
 
-static ast::constant_value evaluate_binary_bit_xor(
+static ast::constant_value_storage evaluate_binary_bit_xor(
 	[[maybe_unused]] ast::expression const &original_expr,
 	ast::expression const &lhs, ast::expression const &rhs,
 	[[maybe_unused]] ctx::parse_context &context
@@ -926,25 +926,25 @@ static ast::constant_value evaluate_binary_bit_xor(
 
 	switch (lhs_value.kind())
 	{
-	static_assert(ast::constant_value::variant_count == 19);
-	case ast::constant_value::uint:
+	static_assert(ast::constant_value_storage::variant_count == 19);
+	case ast::constant_value_storage::uint:
 	{
 		auto const lhs_int_val = lhs_value.get_uint();
 		auto const rhs_int_val = rhs_value.get_uint();
-		return ast::constant_value(lhs_int_val ^ rhs_int_val);
+		return ast::constant_value_storage(lhs_int_val ^ rhs_int_val);
 	}
-	case ast::constant_value::boolean:
+	case ast::constant_value_storage::boolean:
 	{
 		auto const lhs_bool_val = lhs_value.get_boolean();
 		auto const rhs_bool_val = rhs_value.get_boolean();
-		return ast::constant_value(lhs_bool_val != rhs_bool_val);
+		return ast::constant_value_storage(lhs_bool_val != rhs_bool_val);
 	}
 	default:
 		bz_unreachable;
 	}
 }
 
-static ast::constant_value evaluate_binary_bit_or(
+static ast::constant_value_storage evaluate_binary_bit_or(
 	[[maybe_unused]] ast::expression const &original_expr,
 	ast::expression const &lhs, ast::expression const &rhs,
 	[[maybe_unused]] ctx::parse_context &context
@@ -961,25 +961,25 @@ static ast::constant_value evaluate_binary_bit_or(
 
 	switch (lhs_value.kind())
 	{
-	static_assert(ast::constant_value::variant_count == 19);
-	case ast::constant_value::uint:
+	static_assert(ast::constant_value_storage::variant_count == 19);
+	case ast::constant_value_storage::uint:
 	{
 		auto const lhs_int_val = lhs_value.get_uint();
 		auto const rhs_int_val = rhs_value.get_uint();
-		return ast::constant_value(lhs_int_val | rhs_int_val);
+		return ast::constant_value_storage(lhs_int_val | rhs_int_val);
 	}
-	case ast::constant_value::boolean:
+	case ast::constant_value_storage::boolean:
 	{
 		auto const lhs_bool_val = lhs_value.get_boolean();
 		auto const rhs_bool_val = rhs_value.get_boolean();
-		return ast::constant_value(lhs_bool_val || rhs_bool_val);
+		return ast::constant_value_storage(lhs_bool_val || rhs_bool_val);
 	}
 	default:
 		bz_unreachable;
 	}
 }
 
-static ast::constant_value evaluate_binary_bit_left_shift(
+static ast::constant_value_storage evaluate_binary_bit_left_shift(
 	ast::expression const &original_expr,
 	ast::expression const &lhs, ast::expression const &rhs,
 	ctx::parse_context &context
@@ -1010,7 +1010,7 @@ static ast::constant_value evaluate_binary_bit_left_shift(
 		);
 		if (result.has_value())
 		{
-			return ast::constant_value(result.get());
+			return ast::constant_value_storage(result.get());
 		}
 		else
 		{
@@ -1028,7 +1028,7 @@ static ast::constant_value evaluate_binary_bit_left_shift(
 		);
 		if (result.has_value())
 		{
-			return ast::constant_value(result.get());
+			return ast::constant_value_storage(result.get());
 		}
 		else
 		{
@@ -1037,7 +1037,7 @@ static ast::constant_value evaluate_binary_bit_left_shift(
 	}
 }
 
-static ast::constant_value evaluate_binary_bit_right_shift(
+static ast::constant_value_storage evaluate_binary_bit_right_shift(
 	ast::expression const &original_expr,
 	ast::expression const &lhs, ast::expression const &rhs,
 	ctx::parse_context &context
@@ -1068,7 +1068,7 @@ static ast::constant_value evaluate_binary_bit_right_shift(
 		);
 		if (result.has_value())
 		{
-			return ast::constant_value(result.get());
+			return ast::constant_value_storage(result.get());
 		}
 		else
 		{
@@ -1086,7 +1086,7 @@ static ast::constant_value evaluate_binary_bit_right_shift(
 		);
 		if (result.has_value())
 		{
-			return ast::constant_value(result.get());
+			return ast::constant_value_storage(result.get());
 		}
 		else
 		{
@@ -1095,7 +1095,7 @@ static ast::constant_value evaluate_binary_bit_right_shift(
 	}
 }
 
-static ast::constant_value evaluate_binary_bool_and(
+static ast::constant_value_storage evaluate_binary_bool_and(
 	[[maybe_unused]] ast::expression const &original_expr,
 	ast::expression const &lhs, ast::expression const &rhs,
 	[[maybe_unused]] ctx::parse_context &context
@@ -1115,10 +1115,10 @@ static ast::constant_value evaluate_binary_bool_and(
 
 	// short-circuiting is handled elsewhere
 	bz_assert(lhs_bool_val);
-	return ast::constant_value(rhs_bool_val);
+	return ast::constant_value_storage(rhs_bool_val);
 }
 
-static ast::constant_value evaluate_binary_bool_xor(
+static ast::constant_value_storage evaluate_binary_bool_xor(
 	[[maybe_unused]] ast::expression const &original_expr,
 	ast::expression const &lhs, ast::expression const &rhs,
 	[[maybe_unused]] ctx::parse_context &context
@@ -1136,10 +1136,10 @@ static ast::constant_value evaluate_binary_bool_xor(
 	bz_assert(rhs_value.is_boolean());
 	auto const rhs_bool_val = rhs_value.get_boolean();
 
-	return ast::constant_value(lhs_bool_val != rhs_bool_val);
+	return ast::constant_value_storage(lhs_bool_val != rhs_bool_val);
 }
 
-static ast::constant_value evaluate_binary_bool_or(
+static ast::constant_value_storage evaluate_binary_bool_or(
 	[[maybe_unused]] ast::expression const &original_expr,
 	ast::expression const &lhs, ast::expression const &rhs,
 	[[maybe_unused]] ctx::parse_context &context
@@ -1159,10 +1159,10 @@ static ast::constant_value evaluate_binary_bool_or(
 
 	// short-circuiting is handled elsewhere
 	bz_assert(!lhs_bool_val);
-	return ast::constant_value(rhs_bool_val);
+	return ast::constant_value_storage(rhs_bool_val);
 }
 
-static ast::constant_value evaluate_binary_comma(
+static ast::constant_value_storage evaluate_binary_comma(
 	[[maybe_unused]] ast::expression const &original_expr,
 	[[maybe_unused]] ast::expression const &lhs, ast::expression const &rhs,
 	[[maybe_unused]] ctx::parse_context &context
@@ -1173,7 +1173,7 @@ static ast::constant_value evaluate_binary_comma(
 }
 
 
-static ast::constant_value evaluate_binary_op(
+static ast::constant_value_storage evaluate_binary_op(
 	ast::expression const &original_expr,
 	uint32_t op, ast::expression const &lhs, ast::expression const &rhs,
 	ctx::parse_context &context
@@ -1226,7 +1226,7 @@ static ast::constant_value evaluate_binary_op(
 	}
 }
 
-static ast::constant_value evaluate_tuple_subscript(ast::expr_tuple_subscript const &tuple_subscript_expr)
+static ast::constant_value_storage evaluate_tuple_subscript(ast::expr_tuple_subscript const &tuple_subscript_expr)
 {
 	bz_assert(tuple_subscript_expr.index.is<ast::constant_expression>());
 	auto const is_consteval = tuple_subscript_expr.base.elems
@@ -1249,7 +1249,7 @@ static ast::constant_value evaluate_tuple_subscript(ast::expr_tuple_subscript co
 	return tuple_subscript_expr.base.elems[index_int_value].get_constant_value();
 }
 
-static ast::constant_value evaluate_subscript(
+static ast::constant_value_storage evaluate_subscript(
 	ast::expression const &base,
 	ast::expression const &index,
 	ctx::parse_context &context
@@ -1344,45 +1344,45 @@ static ast::constant_value evaluate_subscript(
 			auto const end_index = begin_index + inner_size;
 			switch (value.index())
 			{
-			static_assert(ast::constant_value::variant_count == 19);
-			case ast::constant_value::array:
+			static_assert(ast::constant_value_storage::variant_count == 19);
+			case ast::constant_value_storage::array:
 			{
 				auto const &array_value = value.get_array();
 				bz_assert(end_index <= array_value.size());
-				auto result = ast::constant_value();
-				result.emplace<ast::constant_value::array>(array_value.slice(begin_index, end_index));
+				auto result = ast::constant_value_storage();
+				result.emplace<ast::constant_value_storage::array>(array_value.slice(begin_index, end_index));
 				return result;
 			}
-			case ast::constant_value::sint_array:
+			case ast::constant_value_storage::sint_array:
 			{
 				auto const &array_value = value.get_sint_array();
 				bz_assert(end_index <= array_value.size());
-				auto result = ast::constant_value();
-				result.emplace<ast::constant_value::sint_array>(array_value.slice(begin_index, end_index));
+				auto result = ast::constant_value_storage();
+				result.emplace<ast::constant_value_storage::sint_array>(array_value.slice(begin_index, end_index));
 				return result;
 			}
-			case ast::constant_value::uint_array:
+			case ast::constant_value_storage::uint_array:
 			{
 				auto const &array_value = value.get_uint_array();
 				bz_assert(end_index <= array_value.size());
-				auto result = ast::constant_value();
-				result.emplace<ast::constant_value::uint_array>(array_value.slice(begin_index, end_index));
+				auto result = ast::constant_value_storage();
+				result.emplace<ast::constant_value_storage::uint_array>(array_value.slice(begin_index, end_index));
 				return result;
 			}
-			case ast::constant_value::float32_array:
+			case ast::constant_value_storage::float32_array:
 			{
 				auto const &array_value = value.get_float32_array();
 				bz_assert(end_index <= array_value.size());
-				auto result = ast::constant_value();
-				result.emplace<ast::constant_value::float32_array>(array_value.slice(begin_index, end_index));
+				auto result = ast::constant_value_storage();
+				result.emplace<ast::constant_value_storage::float32_array>(array_value.slice(begin_index, end_index));
 				return result;
 			}
-			case ast::constant_value::float64_array:
+			case ast::constant_value_storage::float64_array:
 			{
 				auto const &array_value = value.get_float64_array();
 				bz_assert(end_index <= array_value.size());
-				auto result = ast::constant_value();
-				result.emplace<ast::constant_value::float64_array>(array_value.slice(begin_index, end_index));
+				auto result = ast::constant_value_storage();
+				result.emplace<ast::constant_value_storage::float64_array>(array_value.slice(begin_index, end_index));
 				return result;
 			}
 			default:
@@ -1393,36 +1393,36 @@ static ast::constant_value evaluate_subscript(
 		{
 			switch (value.index())
 			{
-			static_assert(ast::constant_value::variant_count == 19);
-			case ast::constant_value::array:
+			static_assert(ast::constant_value_storage::variant_count == 19);
+			case ast::constant_value_storage::array:
 			{
 				auto const &array_value = value.get_array();
 				bz_assert(index_value < array_value.size());
 				return array_value[index_value];
 			}
-			case ast::constant_value::sint_array:
+			case ast::constant_value_storage::sint_array:
 			{
 				auto const &array_value = value.get_sint_array();
 				bz_assert(index_value < array_value.size());
-				return ast::constant_value(array_value[index_value]);
+				return ast::constant_value_storage(array_value[index_value]);
 			}
-			case ast::constant_value::uint_array:
+			case ast::constant_value_storage::uint_array:
 			{
 				auto const &array_value = value.get_uint_array();
 				bz_assert(index_value < array_value.size());
-				return ast::constant_value(array_value[index_value]);
+				return ast::constant_value_storage(array_value[index_value]);
 			}
-			case ast::constant_value::float32_array:
+			case ast::constant_value_storage::float32_array:
 			{
 				auto const &array_value = value.get_float32_array();
 				bz_assert(index_value < array_value.size());
-				return ast::constant_value(array_value[index_value]);
+				return ast::constant_value_storage(array_value[index_value]);
 			}
-			case ast::constant_value::float64_array:
+			case ast::constant_value_storage::float64_array:
 			{
 				auto const &array_value = value.get_float64_array();
 				bz_assert(index_value < array_value.size());
-				return ast::constant_value(array_value[index_value]);
+				return ast::constant_value_storage(array_value[index_value]);
 			}
 			default:
 				bz_unreachable;
@@ -1440,7 +1440,7 @@ static ast::constant_value evaluate_subscript(
 }
 
 template<typename Kind>
-static ast::constant_value is_typespec_kind_helper(ast::expr_function_call &func_call)
+static ast::constant_value_storage is_typespec_kind_helper(ast::expr_function_call &func_call)
 {
 	bz_assert(func_call.params.size() == 1);
 	bz_assert(func_call.params[0].is_constant());
@@ -1448,11 +1448,11 @@ static ast::constant_value is_typespec_kind_helper(ast::expr_function_call &func
 	auto const type = func_call.params[0]
 		.get_constant_value()
 		.get_type();
-	return ast::constant_value(type.is<Kind>());
+	return ast::constant_value_storage(type.is<Kind>());
 }
 
 template<typename Kind>
-static ast::constant_value remove_typespec_kind_helper(ast::expr_function_call &func_call)
+static ast::constant_value_storage remove_typespec_kind_helper(ast::expr_function_call &func_call)
 {
 	bz_assert(func_call.params.size() == 1);
 	bz_assert(func_call.params[0].is_constant());
@@ -1462,15 +1462,15 @@ static ast::constant_value remove_typespec_kind_helper(ast::expr_function_call &
 		.get_type();
 	if (type.is<Kind>())
 	{
-		return ast::constant_value(type.get<Kind>());
+		return ast::constant_value_storage(type.get<Kind>());
 	}
 	else
 	{
-		return ast::constant_value(type);
+		return ast::constant_value_storage(type);
 	}
 }
 
-static ast::constant_value evaluate_intrinsic_function_call(
+static ast::constant_value_storage evaluate_intrinsic_function_call(
 	ast::expression const &original_expr,
 	ast::expr_function_call &func_call,
 	ctx::parse_context &context
@@ -1491,7 +1491,7 @@ static ast::constant_value evaluate_intrinsic_function_call(
 		auto const type = func_call.params[0].get_expr_type().remove_mut_reference();
 		bz_assert(type.is<ast::ts_array>());
 		bz_assert(type.get<ast::ts_array>().size != 0);
-		return ast::constant_value(type.get<ast::ts_array>().size);
+		return ast::constant_value_storage(type.get<ast::ts_array>().size);
 	}
 	case ast::function_body::builtin_enum_value:
 	{
@@ -1508,11 +1508,11 @@ static ast::constant_value evaluate_intrinsic_function_call(
 		auto const is_signed = ast::is_signed_integer_kind(decl->underlying_type.get<ast::ts_base_type>().info->kind);
 		if (is_signed)
 		{
-			return ast::constant_value(bit_cast<int64_t>(enum_value));
+			return ast::constant_value_storage(bit_cast<int64_t>(enum_value));
 		}
 		else
 		{
-			return ast::constant_value(enum_value);
+			return ast::constant_value_storage(enum_value);
 		}
 	}
 	case ast::function_body::builtin_is_comptime:
@@ -1538,7 +1538,7 @@ static ast::constant_value evaluate_intrinsic_function_call(
 				lhs += rhs;
 				return lhs;
 			});
-		return ast::constant_value(std::move(result));
+		return ast::constant_value_storage(std::move(result));
 	}
 
 	case ast::function_body::typename_as_str:
@@ -1549,7 +1549,7 @@ static ast::constant_value evaluate_intrinsic_function_call(
 		auto const type = func_call.params[0]
 			.get_constant_value()
 			.get_type();
-		return ast::constant_value(bz::format("{}", type));
+		return ast::constant_value_storage(bz::format("{}", type));
 	}
 
 	case ast::function_body::is_mut:
@@ -1599,11 +1599,11 @@ static ast::constant_value evaluate_intrinsic_function_call(
 				original_expr.src_tokens,
 				bz::format("'__builtin_slice_value_type' called on non-slice type '{}'", type)
 			);
-			return ast::constant_value(type);
+			return ast::constant_value_storage(type);
 		}
 		else
 		{
-			return ast::constant_value(type.get<ast::ts_array_slice>().elem_type);
+			return ast::constant_value_storage(type.get<ast::ts_array_slice>().elem_type);
 		}
 	}
 	case ast::function_body::array_value_type:
@@ -1620,11 +1620,11 @@ static ast::constant_value evaluate_intrinsic_function_call(
 				original_expr.src_tokens,
 				bz::format("'__builtin_array_value_type' called on non-array type '{}'", type)
 			);
-			return ast::constant_value(type);
+			return ast::constant_value_storage(type);
 		}
 		else
 		{
-			return ast::constant_value(type.get<ast::ts_array>().elem_type);
+			return ast::constant_value_storage(type.get<ast::ts_array>().elem_type);
 		}
 	}
 	case ast::function_body::tuple_value_type:
@@ -1646,7 +1646,7 @@ static ast::constant_value evaluate_intrinsic_function_call(
 				original_expr.src_tokens,
 				bz::format("'__builtin_tuple_value_type' called on non-tuple type '{}'", type)
 			);
-			return ast::constant_value(type);
+			return ast::constant_value_storage(type);
 		}
 		else if (index >= type.get<ast::ts_tuple>().types.size())
 		{
@@ -1654,11 +1654,11 @@ static ast::constant_value evaluate_intrinsic_function_call(
 				original_expr.src_tokens,
 				bz::format("index {} is out of range in '__builtin_tuple_value_type' with tuple type '{}'", index, type)
 			);
-			return ast::constant_value(type.get<ast::ts_tuple>().types.back());
+			return ast::constant_value_storage(type.get<ast::ts_tuple>().types.back());
 		}
 		else
 		{
-			return ast::constant_value(type.get<ast::ts_tuple>().types[index]);
+			return ast::constant_value_storage(type.get<ast::ts_tuple>().types[index]);
 		}
 	}
 	case ast::function_body::concat_tuple_types:
@@ -1690,12 +1690,12 @@ static ast::constant_value evaluate_intrinsic_function_call(
 					bz::format("'__builtin_concat_tuple_types' called with non-tuple type '{}' as rhs", rhs_type)
 				);
 			}
-			return ast::constant_value(lhs_type);
+			return ast::constant_value_storage(lhs_type);
 		}
 		else
 		{
-			auto result = ast::constant_value();
-			auto &result_type = result.emplace<ast::constant_value::type>();
+			auto result = ast::constant_value_storage();
+			auto &result_type = result.emplace<ast::constant_value_storage::type>();
 			result_type = ast::make_tuple_typespec(original_expr.src_tokens, {});
 			auto const &lhs_tuple_types = lhs_type.get<ast::ts_tuple>().types;
 			auto const &rhs_tuple_types = rhs_type.get<ast::ts_tuple>().types;
@@ -1722,12 +1722,12 @@ static ast::constant_value evaluate_intrinsic_function_call(
 				original_expr.src_tokens,
 				bz::format("'__builtin_enum_underlying_type' called on non-enum type '{}'", type)
 			);
-			return ast::constant_value(type);
+			return ast::constant_value_storage(type);
 		}
 		else
 		{
 			context.resolve_type(original_expr.src_tokens, type.get<ast::ts_enum>().decl);
-			return ast::constant_value(type.get<ast::ts_enum>().decl->underlying_type);
+			return ast::constant_value_storage(type.get<ast::ts_enum>().decl->underlying_type);
 		}
 	}
 
@@ -1739,7 +1739,7 @@ static ast::constant_value evaluate_intrinsic_function_call(
 		auto const type = func_call.params[0]
 			.get_constant_value()
 			.get_type();
-		return ast::constant_value(context.is_default_constructible(original_expr.src_tokens, type));
+		return ast::constant_value_storage(context.is_default_constructible(original_expr.src_tokens, type));
 	}
 	case ast::function_body::is_copy_constructible:
 	{
@@ -1749,7 +1749,7 @@ static ast::constant_value evaluate_intrinsic_function_call(
 		auto const type = func_call.params[0]
 			.get_constant_value()
 			.get_type();
-		return ast::constant_value(context.is_copy_constructible(original_expr.src_tokens, type));
+		return ast::constant_value_storage(context.is_copy_constructible(original_expr.src_tokens, type));
 	}
 	case ast::function_body::is_trivially_copy_constructible:
 	{
@@ -1759,7 +1759,7 @@ static ast::constant_value evaluate_intrinsic_function_call(
 		auto const type = func_call.params[0]
 			.get_constant_value()
 			.get_type();
-		return ast::constant_value(context.is_trivially_copy_constructible(original_expr.src_tokens, type));
+		return ast::constant_value_storage(context.is_trivially_copy_constructible(original_expr.src_tokens, type));
 	}
 	case ast::function_body::is_move_constructible:
 	{
@@ -1769,7 +1769,7 @@ static ast::constant_value evaluate_intrinsic_function_call(
 		auto const type = func_call.params[0]
 			.get_constant_value()
 			.get_type();
-		return ast::constant_value(context.is_move_constructible(original_expr.src_tokens, type));
+		return ast::constant_value_storage(context.is_move_constructible(original_expr.src_tokens, type));
 	}
 	case ast::function_body::is_trivially_move_constructible:
 	{
@@ -1779,7 +1779,7 @@ static ast::constant_value evaluate_intrinsic_function_call(
 		auto const type = func_call.params[0]
 			.get_constant_value()
 			.get_type();
-		return ast::constant_value(context.is_trivially_move_constructible(original_expr.src_tokens, type));
+		return ast::constant_value_storage(context.is_trivially_move_constructible(original_expr.src_tokens, type));
 	}
 	case ast::function_body::is_trivially_destructible:
 	{
@@ -1789,7 +1789,7 @@ static ast::constant_value evaluate_intrinsic_function_call(
 		auto const type = func_call.params[0]
 			.get_constant_value()
 			.get_type();
-		return ast::constant_value(context.is_trivially_destructible(original_expr.src_tokens, type));
+		return ast::constant_value_storage(context.is_trivially_destructible(original_expr.src_tokens, type));
 	}
 	case ast::function_body::is_trivially_move_destructible:
 	{
@@ -1799,7 +1799,7 @@ static ast::constant_value evaluate_intrinsic_function_call(
 		auto const type = func_call.params[0]
 			.get_constant_value()
 			.get_type();
-		return ast::constant_value(context.is_trivially_move_destructible(original_expr.src_tokens, type));
+		return ast::constant_value_storage(context.is_trivially_move_destructible(original_expr.src_tokens, type));
 	}
 	case ast::function_body::is_trivially_relocatable:
 	{
@@ -1809,7 +1809,7 @@ static ast::constant_value evaluate_intrinsic_function_call(
 		auto const type = func_call.params[0]
 			.get_constant_value()
 			.get_type();
-		return ast::constant_value(context.is_trivially_relocatable(original_expr.src_tokens, type));
+		return ast::constant_value_storage(context.is_trivially_relocatable(original_expr.src_tokens, type));
 	}
 	case ast::function_body::is_trivial:
 	{
@@ -1819,31 +1819,31 @@ static ast::constant_value evaluate_intrinsic_function_call(
 		auto const type = func_call.params[0]
 			.get_constant_value()
 			.get_type();
-		return ast::constant_value(context.is_trivial(original_expr.src_tokens, type));
+		return ast::constant_value_storage(context.is_trivial(original_expr.src_tokens, type));
 	}
 
 	case ast::function_body::i8_default_constructor:
 	case ast::function_body::i16_default_constructor:
 	case ast::function_body::i32_default_constructor:
 	case ast::function_body::i64_default_constructor:
-		return ast::constant_value(int64_t());
+		return ast::constant_value_storage(int64_t());
 	case ast::function_body::u8_default_constructor:
 	case ast::function_body::u16_default_constructor:
 	case ast::function_body::u32_default_constructor:
 	case ast::function_body::u64_default_constructor:
-		return ast::constant_value(uint64_t());
+		return ast::constant_value_storage(uint64_t());
 	case ast::function_body::f32_default_constructor:
-		return ast::constant_value(float32_t());
+		return ast::constant_value_storage(float32_t());
 	case ast::function_body::f64_default_constructor:
-		return ast::constant_value(float64_t());
+		return ast::constant_value_storage(float64_t());
 	case ast::function_body::char_default_constructor:
-		return ast::constant_value(bz::u8char());
+		return ast::constant_value_storage(bz::u8char());
 	case ast::function_body::str_default_constructor:
-		return ast::constant_value(bz::u8string());
+		return ast::constant_value_storage(bz::u8string());
 	case ast::function_body::bool_default_constructor:
-		return ast::constant_value(bool());
+		return ast::constant_value_storage(bool());
 	case ast::function_body::null_t_default_constructor:
-		return ast::constant_value::get_null();
+		return ast::constant_value_storage::get_null();
 
 	case ast::function_body::builtin_unary_plus:
 	{
@@ -1872,7 +1872,7 @@ static ast::constant_value evaluate_intrinsic_function_call(
 			bz_assert(const_expr.type.remove_any_mut().is<ast::ts_base_type>());
 			auto const type = const_expr.type.remove_any_mut().get<ast::ts_base_type>().info->kind;
 			auto const int_val = value.get_sint();
-			return ast::constant_value(safe_unary_minus(
+			return ast::constant_value_storage(safe_unary_minus(
 				original_expr.src_tokens, original_expr.paren_level,
 				int_val, type, context
 			));
@@ -1880,13 +1880,13 @@ static ast::constant_value evaluate_intrinsic_function_call(
 		else if (value.is_float32())
 		{
 			auto const float_val = value.get_float32();
-			return ast::constant_value(-float_val);
+			return ast::constant_value_storage(-float_val);
 		}
 		else
 		{
 			bz_assert(value.is_float64());
 			auto const float_val = value.get_float64();
-			return ast::constant_value(-float_val);
+			return ast::constant_value_storage(-float_val);
 		}
 	}
 	case ast::function_body::builtin_unary_dereference:
@@ -1903,7 +1903,7 @@ static ast::constant_value evaluate_intrinsic_function_call(
 		if (value.is_boolean())
 		{
 			auto const bool_val = value.get_boolean();
-			return ast::constant_value(!bool_val);
+			return ast::constant_value_storage(!bool_val);
 		}
 		else
 		{
@@ -1915,13 +1915,13 @@ static ast::constant_value evaluate_intrinsic_function_call(
 			switch (param_kind)
 			{
 			case ast::type_info::uint8_:
-				return ast::constant_value(uint64_t(uint8_t(~uint_val)));
+				return ast::constant_value_storage(uint64_t(uint8_t(~uint_val)));
 			case ast::type_info::uint16_:
-				return ast::constant_value(uint64_t(uint16_t(~uint_val)));
+				return ast::constant_value_storage(uint64_t(uint16_t(~uint_val)));
 			case ast::type_info::uint32_:
-				return ast::constant_value(uint64_t(uint32_t(~uint_val)));
+				return ast::constant_value_storage(uint64_t(uint32_t(~uint_val)));
 			case ast::type_info::uint64_:
-				return ast::constant_value(~uint_val);
+				return ast::constant_value_storage(~uint_val);
 			default:
 				bz_unreachable;
 			}
@@ -1937,7 +1937,7 @@ static ast::constant_value evaluate_intrinsic_function_call(
 		bz_assert(func_call.params[0].is_constant());
 		bz_assert(func_call.params[0].get_constant_value().is_boolean());
 		auto const bool_val = func_call.params[0].get_constant_value().get_boolean();
-		return ast::constant_value(!bool_val);
+		return ast::constant_value_storage(!bool_val);
 	}
 	case ast::function_body::builtin_unary_plus_plus:
 	case ast::function_body::builtin_unary_minus_minus:
@@ -1988,7 +1988,7 @@ static ast::constant_value evaluate_intrinsic_function_call(
 	}
 }
 
-static ast::constant_value get_default_constructed_value(
+static ast::constant_value_storage get_default_constructed_value(
 	lex::src_tokens const &src_tokens,
 	ast::typespec_view type,
 	ctx::parse_context &context
@@ -2003,12 +2003,12 @@ static ast::constant_value get_default_constructed_value(
 	if (type.modifiers.not_empty())
 	{
 		bz_assert(type.is<ast::ts_optional>());
-		return ast::constant_value::get_null();
+		return ast::constant_value_storage::get_null();
 	}
 	else if (type.is<ast::ts_array>())
 	{
 		auto const [elem_type, size, is_multi_dimensional] = get_flattened_array_type_and_size(type);
-		ast::constant_value result;
+		ast::constant_value_storage result;
 		auto const elem_builtin_kind = elem_type.is<ast::ts_base_type>()
 			? elem_type.get<ast::ts_base_type>().info->kind
 			: ast::type_info::aggregate;
@@ -2018,26 +2018,26 @@ static ast::constant_value get_default_constructed_value(
 		case ast::type_info::int16_:
 		case ast::type_info::int32_:
 		case ast::type_info::int64_:
-			result.emplace<ast::constant_value::sint_array>(size, 0);
+			result.emplace<ast::constant_value_storage::sint_array>(size, 0);
 			break;
 		case ast::type_info::uint8_:
 		case ast::type_info::uint16_:
 		case ast::type_info::uint32_:
 		case ast::type_info::uint64_:
-			result.emplace<ast::constant_value::uint_array>(size, 0);
+			result.emplace<ast::constant_value_storage::uint_array>(size, 0);
 			break;
 		case ast::type_info::float32_:
-			result.emplace<ast::constant_value::float32_array>(size, 0.0f);
+			result.emplace<ast::constant_value_storage::float32_array>(size, 0.0f);
 			break;
 		case ast::type_info::float64_:
-			result.emplace<ast::constant_value::float64_array>(size, 0.0);
+			result.emplace<ast::constant_value_storage::float64_array>(size, 0.0);
 			break;
 		default:
 		{
 			auto const elem_value = get_default_constructed_value(src_tokens, elem_type, context);
 			if (elem_value.not_null())
 			{
-				result.emplace<ast::constant_value::array>(size, elem_value);
+				result.emplace<ast::constant_value_storage::array>(size, elem_value);
 			}
 			break;
 		}
@@ -2047,7 +2047,7 @@ static ast::constant_value get_default_constructed_value(
 	else
 	{
 		return type.terminator->visit(bz::overload{
-			[&src_tokens, &context](ast::ts_base_type const &base_t) -> ast::constant_value {
+			[&src_tokens, &context](ast::ts_base_type const &base_t) -> ast::constant_value_storage {
 				if (base_t.info->kind != ast::type_info::aggregate)
 				{
 					switch (base_t.info->kind)
@@ -2056,24 +2056,24 @@ static ast::constant_value get_default_constructed_value(
 					case ast::type_info::int16_:
 					case ast::type_info::int32_:
 					case ast::type_info::int64_:
-						return ast::constant_value(int64_t());
+						return ast::constant_value_storage(int64_t());
 					case ast::type_info::uint8_:
 					case ast::type_info::uint16_:
 					case ast::type_info::uint32_:
 					case ast::type_info::uint64_:
-						return ast::constant_value(uint64_t());
+						return ast::constant_value_storage(uint64_t());
 					case ast::type_info::float32_:
-						return ast::constant_value(float32_t());
+						return ast::constant_value_storage(float32_t());
 					case ast::type_info::float64_:
-						return ast::constant_value(float64_t());
+						return ast::constant_value_storage(float64_t());
 					case ast::type_info::char_:
-						return ast::constant_value(bz::u8char());
+						return ast::constant_value_storage(bz::u8char());
 					case ast::type_info::str_:
-						return ast::constant_value(bz::u8string());
+						return ast::constant_value_storage(bz::u8string());
 					case ast::type_info::bool_:
-						return ast::constant_value(bool());
+						return ast::constant_value_storage(bool());
 					case ast::type_info::null_t_:
-						return ast::constant_value::get_null();
+						return ast::constant_value_storage::get_null();
 
 					default:
 						bz_unreachable;
@@ -2081,8 +2081,8 @@ static ast::constant_value get_default_constructed_value(
 				}
 				else if (base_t.info->kind == ast::type_info::aggregate && base_t.info->default_constructor == nullptr)
 				{
-					ast::constant_value result;
-					auto &elems = result.emplace<ast::constant_value::aggregate>();
+					ast::constant_value_storage result;
+					auto &elems = result.emplace<ast::constant_value_storage::aggregate>();
 					elems.reserve(base_t.info->member_variables.size());
 					for (auto const member : base_t.info->member_variables)
 					{
@@ -2100,12 +2100,12 @@ static ast::constant_value get_default_constructed_value(
 					return {};
 				}
 			},
-			[](ast::ts_array_slice const &) -> ast::constant_value {
+			[](ast::ts_array_slice const &) -> ast::constant_value_storage {
 				return {};
 			},
-			[&src_tokens, &context](ast::ts_tuple const &tuple_t) -> ast::constant_value {
-				ast::constant_value result;
-				auto &elems = result.emplace<ast::constant_value::tuple>();
+			[&src_tokens, &context](ast::ts_tuple const &tuple_t) -> ast::constant_value_storage {
+				ast::constant_value_storage result;
+				auto &elems = result.emplace<ast::constant_value_storage::tuple>();
 				elems.reserve(tuple_t.types.size());
 				for (auto const &type : tuple_t.types)
 				{
@@ -2118,14 +2118,14 @@ static ast::constant_value get_default_constructed_value(
 				}
 				return result;
 			},
-			[](auto const &) -> ast::constant_value {
+			[](auto const &) -> ast::constant_value_storage {
 				bz_unreachable;
 			}
 		});
 	}
 }
 
-static ast::constant_value consteval_guaranteed_function_call(
+static ast::constant_value_storage consteval_guaranteed_function_call(
 	ast::expression const &original_expr,
 	ast::expr_function_call &func_call,
 	ctx::parse_context &context
@@ -2150,7 +2150,7 @@ static ast::constant_value consteval_guaranteed_function_call(
 	}
 }
 
-static ast::constant_value evaluate_cast(
+static ast::constant_value_storage evaluate_cast(
 	ast::expression const &original_expr,
 	ast::expr_cast const &subscript_expr,
 	ctx::parse_context &context
@@ -2177,8 +2177,8 @@ static ast::constant_value evaluate_cast(
 	{
 		switch (value.kind())
 		{
-		static_assert(ast::constant_value::variant_count == 19);
-		case ast::constant_value::sint:
+		static_assert(ast::constant_value_storage::variant_count == 19);
+		case ast::constant_value_storage::sint:
 		{
 			using T = std::tuple<bz::u8string_view, int64_t, int64_t, int64_t>;
 			auto const int_val = value.get_sint();
@@ -2195,9 +2195,9 @@ static ast::constant_value evaluate_cast(
 					bz::format("overflow in constant expression '{} as {}' results in {}", int_val, type_name, result)
 				);
 			}
-			return ast::constant_value(result);
+			return ast::constant_value_storage(result);
 		}
-		case ast::constant_value::uint:
+		case ast::constant_value_storage::uint:
 		{
 			using T = std::tuple<bz::u8string_view, int64_t, int64_t>;
 			auto const int_val = value.get_uint();
@@ -2214,9 +2214,9 @@ static ast::constant_value evaluate_cast(
 					bz::format("overflow in constant expression '{} as {}' results in {}", int_val, type_name, result)
 				);
 			}
-			return ast::constant_value(result);
+			return ast::constant_value_storage(result);
 		}
-		case ast::constant_value::float32:
+		case ast::constant_value_storage::float32:
 		{
 			auto const float_val = value.get_float32();
 			auto const result =
@@ -2224,9 +2224,9 @@ static ast::constant_value evaluate_cast(
 				dest_kind == ast::type_info::int16_ ? static_cast<int16_t>(float_val) :
 				dest_kind == ast::type_info::int32_ ? static_cast<int32_t>(float_val) :
 				static_cast<int64_t>(float_val);
-			return ast::constant_value(result);
+			return ast::constant_value_storage(result);
 		}
-		case ast::constant_value::float64:
+		case ast::constant_value_storage::float64:
 		{
 			auto const float_val = value.get_float64();
 			auto const result =
@@ -2234,13 +2234,13 @@ static ast::constant_value evaluate_cast(
 				dest_kind == ast::type_info::int16_ ? static_cast<int16_t>(float_val) :
 				dest_kind == ast::type_info::int32_ ? static_cast<int32_t>(float_val) :
 				static_cast<int64_t>(float_val);
-			return ast::constant_value(result);
+			return ast::constant_value_storage(result);
 		}
-		case ast::constant_value::u8char:
+		case ast::constant_value_storage::u8char:
 			// no overflow possible in constant expressions
-			return ast::constant_value(static_cast<int64_t>(value.get_u8char()));
-		case ast::constant_value::boolean:
-			return ast::constant_value(static_cast<int64_t>(value.get_boolean()));
+			return ast::constant_value_storage(static_cast<int64_t>(value.get_u8char()));
+		case ast::constant_value_storage::boolean:
+			return ast::constant_value_storage(static_cast<int64_t>(value.get_boolean()));
 		default:
 			bz_unreachable;
 		}
@@ -2253,8 +2253,8 @@ static ast::constant_value evaluate_cast(
 	{
 		switch (value.kind())
 		{
-		static_assert(ast::constant_value::variant_count == 19);
-		case ast::constant_value::sint:
+		static_assert(ast::constant_value_storage::variant_count == 19);
+		case ast::constant_value_storage::sint:
 		{
 			using T = std::tuple<bz::u8string_view, uint64_t, uint64_t>;
 			auto const int_val = value.get_sint();
@@ -2271,9 +2271,9 @@ static ast::constant_value evaluate_cast(
 					bz::format("overflow in constant expression '{} as {}' results in {}", int_val, type_name, result)
 				);
 			}
-			return ast::constant_value(result);
+			return ast::constant_value_storage(result);
 		}
-		case ast::constant_value::uint:
+		case ast::constant_value_storage::uint:
 		{
 			using T = std::tuple<bz::u8string_view, uint64_t, uint64_t>;
 			auto const int_val = value.get_uint();
@@ -2290,9 +2290,9 @@ static ast::constant_value evaluate_cast(
 					bz::format("overflow in constant expression '{} as {}' results in {}", int_val, type_name, result)
 				);
 			}
-			return ast::constant_value(result);
+			return ast::constant_value_storage(result);
 		}
-		case ast::constant_value::float32:
+		case ast::constant_value_storage::float32:
 		{
 			auto const float_val = value.get_float32();
 			auto const result =
@@ -2300,9 +2300,9 @@ static ast::constant_value evaluate_cast(
 				dest_kind == ast::type_info::uint16_ ? static_cast<uint16_t>(float_val) :
 				dest_kind == ast::type_info::uint32_ ? static_cast<uint32_t>(float_val) :
 				static_cast<uint64_t>(float_val);
-			return ast::constant_value(result);
+			return ast::constant_value_storage(result);
 		}
-		case ast::constant_value::float64:
+		case ast::constant_value_storage::float64:
 		{
 			auto const float_val = value.get_float64();
 			auto const result =
@@ -2310,13 +2310,13 @@ static ast::constant_value evaluate_cast(
 				dest_kind == ast::type_info::uint16_ ? static_cast<uint16_t>(float_val) :
 				dest_kind == ast::type_info::uint32_ ? static_cast<uint32_t>(float_val) :
 				static_cast<uint64_t>(float_val);
-			return ast::constant_value(result);
+			return ast::constant_value_storage(result);
 		}
-		case ast::constant_value::u8char:
+		case ast::constant_value_storage::u8char:
 			// no overflow possible in constant expressions
-			return ast::constant_value(static_cast<uint64_t>(value.get_u8char()));
-		case ast::constant_value::boolean:
-			return ast::constant_value(static_cast<uint64_t>(value.get_boolean()));
+			return ast::constant_value_storage(static_cast<uint64_t>(value.get_u8char()));
+		case ast::constant_value_storage::boolean:
+			return ast::constant_value_storage(static_cast<uint64_t>(value.get_boolean()));
 		default:
 			bz_unreachable;
 		}
@@ -2325,38 +2325,38 @@ static ast::constant_value evaluate_cast(
 	case ast::type_info::float32_:
 		switch (value.kind())
 		{
-		static_assert(ast::constant_value::variant_count == 19);
-		case ast::constant_value::sint:
-			return ast::constant_value(static_cast<float32_t>(value.get_sint()));
-		case ast::constant_value::uint:
-			return ast::constant_value(static_cast<float32_t>(value.get_uint()));
-		case ast::constant_value::float32:
-			return ast::constant_value(static_cast<float32_t>(value.get_float32()));
-		case ast::constant_value::float64:
-			return ast::constant_value(static_cast<float32_t>(value.get_float64()));
+		static_assert(ast::constant_value_storage::variant_count == 19);
+		case ast::constant_value_storage::sint:
+			return ast::constant_value_storage(static_cast<float32_t>(value.get_sint()));
+		case ast::constant_value_storage::uint:
+			return ast::constant_value_storage(static_cast<float32_t>(value.get_uint()));
+		case ast::constant_value_storage::float32:
+			return ast::constant_value_storage(static_cast<float32_t>(value.get_float32()));
+		case ast::constant_value_storage::float64:
+			return ast::constant_value_storage(static_cast<float32_t>(value.get_float64()));
 		default:
 			bz_unreachable;
 		}
 	case ast::type_info::float64_:
 		switch (value.kind())
 		{
-		static_assert(ast::constant_value::variant_count == 19);
-		case ast::constant_value::sint:
-			return ast::constant_value(static_cast<float64_t>(value.get_sint()));
-		case ast::constant_value::uint:
-			return ast::constant_value(static_cast<float64_t>(value.get_uint()));
-		case ast::constant_value::float32:
-			return ast::constant_value(static_cast<float64_t>(value.get_float32()));
-		case ast::constant_value::float64:
-			return ast::constant_value(static_cast<float64_t>(value.get_float64()));
+		static_assert(ast::constant_value_storage::variant_count == 19);
+		case ast::constant_value_storage::sint:
+			return ast::constant_value_storage(static_cast<float64_t>(value.get_sint()));
+		case ast::constant_value_storage::uint:
+			return ast::constant_value_storage(static_cast<float64_t>(value.get_uint()));
+		case ast::constant_value_storage::float32:
+			return ast::constant_value_storage(static_cast<float64_t>(value.get_float32()));
+		case ast::constant_value_storage::float64:
+			return ast::constant_value_storage(static_cast<float64_t>(value.get_float64()));
 		default:
 			bz_unreachable;
 		}
 	case ast::type_info::char_:
 		switch (value.kind())
 		{
-		static_assert(ast::constant_value::variant_count == 19);
-		case ast::constant_value::sint:
+		static_assert(ast::constant_value_storage::variant_count == 19);
+		case ast::constant_value_storage::sint:
 		{
 			auto const result = static_cast<bz::u8char>(value.get_sint());
 			if (!bz::is_valid_unicode_value(result))
@@ -2371,9 +2371,9 @@ static ast::constant_value evaluate_cast(
 				}
 				return {};
 			}
-			return ast::constant_value(result);
+			return ast::constant_value_storage(result);
 		}
-		case ast::constant_value::uint:
+		case ast::constant_value_storage::uint:
 		{
 			auto const result = static_cast<bz::u8char>(value.get_uint());
 			if (!bz::is_valid_unicode_value(result))
@@ -2388,7 +2388,7 @@ static ast::constant_value evaluate_cast(
 				}
 				return {};
 			}
-			return ast::constant_value(result);
+			return ast::constant_value_storage(result);
 		}
 		default:
 			bz_unreachable;
@@ -2469,7 +2469,7 @@ static bool consteval_guaranteed_special_array_value_helper(
 	return true;
 }
 
-static ast::constant_value consteval_guaranteed_special_array_value(
+static ast::constant_value_storage consteval_guaranteed_special_array_value(
 	ast::typespec_view array_type,
 	bz::array_view<ast::expression> exprs,
 	ctx::parse_context &context
@@ -2486,13 +2486,13 @@ static ast::constant_value consteval_guaranteed_special_array_value(
 	case ast::type_info::int32_:
 	case ast::type_info::int64_:
 	{
-		auto result = ast::constant_value();
-		auto &sint_array = result.emplace<ast::constant_value::sint_array>();
+		auto result = ast::constant_value_storage();
+		auto &sint_array = result.emplace<ast::constant_value_storage::sint_array>();
 		sint_array.reserve(size);
 
 		auto const good = consteval_guaranteed_special_array_value_helper<
-			ast::constant_value::sint,
-			ast::constant_value::sint_array
+			ast::constant_value_storage::sint,
+			ast::constant_value_storage::sint_array
 		>(
 			sint_array,
 			array_type.get<ast::ts_array>().elem_type,
@@ -2511,13 +2511,13 @@ static ast::constant_value consteval_guaranteed_special_array_value(
 	case ast::type_info::uint32_:
 	case ast::type_info::uint64_:
 	{
-		auto result = ast::constant_value();
-		auto &uint_array = result.emplace<ast::constant_value::uint_array>();
+		auto result = ast::constant_value_storage();
+		auto &uint_array = result.emplace<ast::constant_value_storage::uint_array>();
 		uint_array.reserve(size);
 
 		auto const good = consteval_guaranteed_special_array_value_helper<
-			ast::constant_value::uint,
-			ast::constant_value::uint_array
+			ast::constant_value_storage::uint,
+			ast::constant_value_storage::uint_array
 		>(
 			uint_array,
 			array_type.get<ast::ts_array>().elem_type,
@@ -2533,13 +2533,13 @@ static ast::constant_value consteval_guaranteed_special_array_value(
 	}
 	case ast::type_info::float32_:
 	{
-		auto result = ast::constant_value();
-		auto &float32_array = result.emplace<ast::constant_value::float32_array>();
+		auto result = ast::constant_value_storage();
+		auto &float32_array = result.emplace<ast::constant_value_storage::float32_array>();
 		float32_array.reserve(size);
 
 		auto const good = consteval_guaranteed_special_array_value_helper<
-			ast::constant_value::float32,
-			ast::constant_value::float32_array
+			ast::constant_value_storage::float32,
+			ast::constant_value_storage::float32_array
 		>(
 			float32_array,
 			array_type.get<ast::ts_array>().elem_type,
@@ -2555,13 +2555,13 @@ static ast::constant_value consteval_guaranteed_special_array_value(
 	}
 	case ast::type_info::float64_:
 	{
-		auto result = ast::constant_value();
-		auto &float64_array = result.emplace<ast::constant_value::float64_array>();
+		auto result = ast::constant_value_storage();
+		auto &float64_array = result.emplace<ast::constant_value_storage::float64_array>();
 		float64_array.reserve(size);
 
 		auto const good = consteval_guaranteed_special_array_value_helper<
-			ast::constant_value::float64,
-			ast::constant_value::float64_array
+			ast::constant_value_storage::float64,
+			ast::constant_value_storage::float64_array
 		>(
 			float64_array,
 			array_type.get<ast::ts_array>().elem_type,
@@ -2580,7 +2580,7 @@ static ast::constant_value consteval_guaranteed_special_array_value(
 	}
 }
 
-static ast::constant_value get_special_array_value(ast::typespec_view array_type, bz::array_view<ast::expression const> exprs)
+static ast::constant_value_storage get_special_array_value(ast::typespec_view array_type, bz::array_view<ast::expression const> exprs)
 {
 	auto const [elem_type, size, is_multi_dimensional] = get_flattened_array_type_and_size(array_type);
 	bz_assert(elem_type.is<ast::ts_base_type>());
@@ -2593,8 +2593,8 @@ static ast::constant_value get_special_array_value(ast::typespec_view array_type
 	case ast::type_info::int32_:
 	case ast::type_info::int64_:
 	{
-		auto result = ast::constant_value();
-		auto &sint_array = result.emplace<ast::constant_value::sint_array>();
+		auto result = ast::constant_value_storage();
+		auto &sint_array = result.emplace<ast::constant_value_storage::sint_array>();
 		sint_array.reserve(size);
 		if (is_multi_dimensional)
 		{
@@ -2617,8 +2617,8 @@ static ast::constant_value get_special_array_value(ast::typespec_view array_type
 	case ast::type_info::uint32_:
 	case ast::type_info::uint64_:
 	{
-		auto result = ast::constant_value();
-		auto &uint_array = result.emplace<ast::constant_value::uint_array>();
+		auto result = ast::constant_value_storage();
+		auto &uint_array = result.emplace<ast::constant_value_storage::uint_array>();
 		uint_array.reserve(size);
 		if (is_multi_dimensional)
 		{
@@ -2638,8 +2638,8 @@ static ast::constant_value get_special_array_value(ast::typespec_view array_type
 	}
 	case ast::type_info::float32_:
 	{
-		auto result = ast::constant_value();
-		auto &float32_array = result.emplace<ast::constant_value::float32_array>();
+		auto result = ast::constant_value_storage();
+		auto &float32_array = result.emplace<ast::constant_value_storage::float32_array>();
 		float32_array.reserve(size);
 		if (is_multi_dimensional)
 		{
@@ -2659,8 +2659,8 @@ static ast::constant_value get_special_array_value(ast::typespec_view array_type
 	}
 	case ast::type_info::float64_:
 	{
-		auto result = ast::constant_value();
-		auto &float64_array = result.emplace<ast::constant_value::float64_array>();
+		auto result = ast::constant_value_storage();
+		auto &float64_array = result.emplace<ast::constant_value_storage::float64_array>();
 		float64_array.reserve(size);
 		if (is_multi_dimensional)
 		{
@@ -2683,77 +2683,77 @@ static ast::constant_value get_special_array_value(ast::typespec_view array_type
 	}
 }
 
-static ast::constant_value guaranteed_evaluate_expr(
+static ast::constant_value_storage guaranteed_evaluate_expr(
 	ast::expression &expr,
 	ctx::parse_context &context
 )
 {
 	return expr.get_expr().visit(bz::overload{
-		[](ast::expr_variable_name &) -> ast::constant_value {
+		[](ast::expr_variable_name &) -> ast::constant_value_storage {
 			// identifiers are only constant expressions if they are a consteval
 			// variable, which is handled in parse_context::make_identifier_expr (or something similar)
 			return {};
 		},
-		[](ast::expr_function_name &) -> ast::constant_value {
+		[](ast::expr_function_name &) -> ast::constant_value_storage {
 			// these are always constant expressions
 			bz_unreachable;
 		},
-		[](ast::expr_function_alias_name &) -> ast::constant_value {
+		[](ast::expr_function_alias_name &) -> ast::constant_value_storage {
 			// these are always constant expressions
 			bz_unreachable;
 		},
-		[](ast::expr_function_overload_set &) -> ast::constant_value {
+		[](ast::expr_function_overload_set &) -> ast::constant_value_storage {
 			// these are always constant expressions
 			bz_unreachable;
 		},
-		[](ast::expr_struct_name &) -> ast::constant_value {
+		[](ast::expr_struct_name &) -> ast::constant_value_storage {
 			// these are always constant expressions
 			bz_unreachable;
 		},
-		[](ast::expr_enum_name &) -> ast::constant_value {
+		[](ast::expr_enum_name &) -> ast::constant_value_storage {
 			// these are always constant expressions
 			bz_unreachable;
 		},
-		[](ast::expr_type_alias_name &) -> ast::constant_value {
+		[](ast::expr_type_alias_name &) -> ast::constant_value_storage {
 			// these are always constant expressions
 			bz_unreachable;
 		},
-		[](ast::expr_integer_literal &) -> ast::constant_value {
+		[](ast::expr_integer_literal &) -> ast::constant_value_storage {
 			// these are always constant expressions
 			bz_unreachable;
 		},
-		[](ast::expr_null_literal &) -> ast::constant_value {
+		[](ast::expr_null_literal &) -> ast::constant_value_storage {
 			// these are always constant expressions
 			bz_unreachable;
 		},
-		[](ast::expr_enum_literal &) -> ast::constant_value {
+		[](ast::expr_enum_literal &) -> ast::constant_value_storage {
 			// these are always constant expressions
 			bz_unreachable;
 		},
-		[](ast::expr_typed_literal &) -> ast::constant_value {
+		[](ast::expr_typed_literal &) -> ast::constant_value_storage {
 			// these are always constant expressions
 			bz_unreachable;
 		},
-		[](ast::expr_placeholder_literal &) -> ast::constant_value {
+		[](ast::expr_placeholder_literal &) -> ast::constant_value_storage {
 			return {};
 		},
-		[](ast::expr_typename_literal &) -> ast::constant_value {
+		[](ast::expr_typename_literal &) -> ast::constant_value_storage {
 			// these are always constant expressions
 			bz_unreachable;
 		},
-		[&context](ast::expr_tuple &tuple) -> ast::constant_value {
+		[&context](ast::expr_tuple &tuple) -> ast::constant_value_storage {
 			for (auto &elem : tuple.elems)
 			{
 				consteval_guaranteed(elem, context);
 			}
 			return {};
 		},
-		[&context](ast::expr_unary_op &unary_op) -> ast::constant_value {
+		[&context](ast::expr_unary_op &unary_op) -> ast::constant_value_storage {
 			// builtin operators are handled as intrinsic functions
 			consteval_guaranteed(unary_op.expr, context);
 			return {};
 		},
-		[&expr, &context](ast::expr_binary_op &binary_op) -> ast::constant_value {
+		[&expr, &context](ast::expr_binary_op &binary_op) -> ast::constant_value_storage {
 			consteval_guaranteed(binary_op.lhs, context);
 			consteval_guaranteed(binary_op.rhs, context);
 
@@ -2769,7 +2769,7 @@ static ast::constant_value guaranteed_evaluate_expr(
 					auto const lhs_bool_val = lhs_value.get_boolean();
 					if (!lhs_bool_val)
 					{
-						return ast::constant_value(false);
+						return ast::constant_value_storage(false);
 					}
 				}
 				else if (op == lex::token::bool_or)
@@ -2780,7 +2780,7 @@ static ast::constant_value guaranteed_evaluate_expr(
 					auto const lhs_bool_val = lhs_value.get_boolean();
 					if (lhs_bool_val)
 					{
-						return ast::constant_value(true);
+						return ast::constant_value_storage(true);
 					}
 				}
 			}
@@ -2794,7 +2794,7 @@ static ast::constant_value guaranteed_evaluate_expr(
 				return {};
 			}
 		},
-		[&context](ast::expr_tuple_subscript &tuple_subscript_expr) -> ast::constant_value {
+		[&context](ast::expr_tuple_subscript &tuple_subscript_expr) -> ast::constant_value_storage {
 			for (auto &elem : tuple_subscript_expr.base.elems)
 			{
 				consteval_guaranteed(elem, context);
@@ -2802,7 +2802,7 @@ static ast::constant_value guaranteed_evaluate_expr(
 
 			return evaluate_tuple_subscript(tuple_subscript_expr);
 		},
-		[&context](ast::expr_rvalue_tuple_subscript &rvalue_tuple_subscript_expr) -> ast::constant_value {
+		[&context](ast::expr_rvalue_tuple_subscript &rvalue_tuple_subscript_expr) -> ast::constant_value_storage {
 			consteval_guaranteed(rvalue_tuple_subscript_expr.base, context);
 
 			if (rvalue_tuple_subscript_expr.base.is_constant())
@@ -2821,7 +2821,7 @@ static ast::constant_value guaranteed_evaluate_expr(
 				return {};
 			}
 		},
-		[&context](ast::expr_subscript &subscript_expr) -> ast::constant_value {
+		[&context](ast::expr_subscript &subscript_expr) -> ast::constant_value_storage {
 			consteval_guaranteed(subscript_expr.base, context);
 			consteval_guaranteed(subscript_expr.index, context);
 
@@ -2829,20 +2829,20 @@ static ast::constant_value guaranteed_evaluate_expr(
 			// lvalue reference to an rvalue
 			return {};
 		},
-		[&context](ast::expr_rvalue_array_subscript &rvalue_array_subscript_expr) -> ast::constant_value {
+		[&context](ast::expr_rvalue_array_subscript &rvalue_array_subscript_expr) -> ast::constant_value_storage {
 			consteval_guaranteed(rvalue_array_subscript_expr.base, context);
 			consteval_guaranteed(rvalue_array_subscript_expr.index, context);
 
 			return evaluate_subscript(rvalue_array_subscript_expr.base, rvalue_array_subscript_expr.index, context);
 		},
-		[&expr, &context](ast::expr_function_call &func_call) -> ast::constant_value {
+		[&expr, &context](ast::expr_function_call &func_call) -> ast::constant_value_storage {
 			for (auto &param : func_call.params)
 			{
 				consteval_guaranteed(param, context);
 			}
 			return consteval_guaranteed_function_call(expr, func_call, context);
 		},
-		[&context](ast::expr_indirect_function_call &func_call) -> ast::constant_value {
+		[&context](ast::expr_indirect_function_call &func_call) -> ast::constant_value_storage {
 			consteval_guaranteed(func_call.called, context);
 			for (auto &param : func_call.params)
 			{
@@ -2850,7 +2850,7 @@ static ast::constant_value guaranteed_evaluate_expr(
 			}
 			return {};
 		},
-		[&expr, &context](ast::expr_cast &cast_expr) -> ast::constant_value {
+		[&expr, &context](ast::expr_cast &cast_expr) -> ast::constant_value_storage {
 			consteval_guaranteed(cast_expr.expr, context);
 			if (cast_expr.expr.has_consteval_succeeded())
 			{
@@ -2861,11 +2861,11 @@ static ast::constant_value guaranteed_evaluate_expr(
 				return {};
 			}
 		},
-		[&context](ast::expr_bit_cast &bit_cast_expr) -> ast::constant_value {
+		[&context](ast::expr_bit_cast &bit_cast_expr) -> ast::constant_value_storage {
 			consteval_guaranteed(bit_cast_expr.expr, context);
 			return {};
 		},
-		[&context](ast::expr_optional_cast &optional_cast_expr) -> ast::constant_value {
+		[&context](ast::expr_optional_cast &optional_cast_expr) -> ast::constant_value_storage {
 			consteval_guaranteed(optional_cast_expr.expr, context);
 			if (optional_cast_expr.expr.has_consteval_succeeded())
 			{
@@ -2876,13 +2876,13 @@ static ast::constant_value guaranteed_evaluate_expr(
 				return {};
 			}
 		},
-		[](ast::expr_take_reference const &) -> ast::constant_value {
+		[](ast::expr_take_reference const &) -> ast::constant_value_storage {
 			return {};
 		},
-		[](ast::expr_take_move_reference const &) -> ast::constant_value {
+		[](ast::expr_take_move_reference const &) -> ast::constant_value_storage {
 			return {};
 		},
-		[&context](ast::expr_aggregate_init &aggregate_init_expr) -> ast::constant_value {
+		[&context](ast::expr_aggregate_init &aggregate_init_expr) -> ast::constant_value_storage {
 			if (is_special_array_type(aggregate_init_expr.type))
 			{
 				auto result = consteval_guaranteed_special_array_value(aggregate_init_expr.type, aggregate_init_expr.exprs, context);
@@ -2910,8 +2910,8 @@ static ast::constant_value guaranteed_evaluate_expr(
 			else if (aggregate_init_expr.type.is<ast::ts_array>())
 			{
 				auto const [elem_type, size, is_multi_dimensional] = get_flattened_array_type_and_size(aggregate_init_expr.type);
-				auto result = ast::constant_value();
-				auto &array = result.emplace<ast::constant_value::array>();
+				auto result = ast::constant_value_storage();
+				auto &array = result.emplace<ast::constant_value_storage::array>();
 				array.reserve(size);
 				if (is_multi_dimensional)
 				{
@@ -2932,8 +2932,8 @@ static ast::constant_value guaranteed_evaluate_expr(
 			}
 			else
 			{
-				auto result = ast::constant_value();
-				auto &aggregate = result.emplace<ast::constant_value::aggregate>();
+				auto result = ast::constant_value_storage();
+				auto &aggregate = result.emplace<ast::constant_value_storage::aggregate>();
 				aggregate.reserve(aggregate_init_expr.exprs.size());
 				for (auto const &expr : aggregate_init_expr.exprs)
 				{
@@ -2942,11 +2942,11 @@ static ast::constant_value guaranteed_evaluate_expr(
 				return result;
 			}
 		},
-		[&context](ast::expr_array_value_init &array_value_init_expr) -> ast::constant_value {
+		[&context](ast::expr_array_value_init &array_value_init_expr) -> ast::constant_value_storage {
 			consteval_guaranteed(array_value_init_expr.value, context);
 			return {};
 		},
-		[&context](ast::expr_aggregate_default_construct &aggregate_default_construct_expr) -> ast::constant_value {
+		[&context](ast::expr_aggregate_default_construct &aggregate_default_construct_expr) -> ast::constant_value_storage {
 			bool is_consteval = true;
 			for (auto &expr : aggregate_default_construct_expr.default_construct_exprs)
 			{
@@ -2958,10 +2958,10 @@ static ast::constant_value guaranteed_evaluate_expr(
 				return {};
 			}
 
-			ast::constant_value result{};
+			ast::constant_value_storage result{};
 			auto &aggregate = aggregate_default_construct_expr.type.is<ast::ts_tuple>()
-				? result.emplace<ast::constant_value::tuple>()
-				: result.emplace<ast::constant_value::aggregate>();
+				? result.emplace<ast::constant_value_storage::tuple>()
+				: result.emplace<ast::constant_value_storage::aggregate>();
 			aggregate.reserve(aggregate_default_construct_expr.default_construct_exprs.size());
 			for (auto const &expr : aggregate_default_construct_expr.default_construct_exprs)
 			{
@@ -2969,7 +2969,7 @@ static ast::constant_value guaranteed_evaluate_expr(
 			}
 			return result;
 		},
-		[&expr, &context](ast::expr_aggregate_copy_construct &aggregate_copy_construct_expr) -> ast::constant_value {
+		[&expr, &context](ast::expr_aggregate_copy_construct &aggregate_copy_construct_expr) -> ast::constant_value_storage {
 			consteval_guaranteed(aggregate_copy_construct_expr.copied_value, context);
 			if (!aggregate_copy_construct_expr.copied_value.has_consteval_succeeded())
 			{
@@ -2985,11 +2985,11 @@ static ast::constant_value guaranteed_evaluate_expr(
 				return {};
 			}
 		},
-		[&context](ast::expr_aggregate_move_construct &aggregate_move_construct_expr) -> ast::constant_value {
+		[&context](ast::expr_aggregate_move_construct &aggregate_move_construct_expr) -> ast::constant_value_storage {
 			consteval_guaranteed(aggregate_move_construct_expr.moved_value, context);
 			return {};
 		},
-		[&expr, &context](ast::expr_array_default_construct &array_default_construct_expr) -> ast::constant_value {
+		[&expr, &context](ast::expr_array_default_construct &array_default_construct_expr) -> ast::constant_value_storage {
 			auto const type = array_default_construct_expr.type.as_typespec_view();
 			bz_assert(type.is<ast::ts_array>());
 			consteval_guaranteed(array_default_construct_expr.default_construct_expr, context);
@@ -3006,20 +3006,20 @@ static ast::constant_value guaranteed_evaluate_expr(
 			{
 				auto const &value = array_default_construct_expr.default_construct_expr.get_constant_value();
 				auto const [elem_type, size, is_multi_dimensional] = get_flattened_array_type_and_size(type);
-				auto result = ast::constant_value();
+				auto result = ast::constant_value_storage();
 				if (is_multi_dimensional)
 				{
 					bz_assert(value.is_array() && value.get_array().not_empty());
-					result.emplace<ast::constant_value::array>(size, value.get_array()[0]);
+					result.emplace<ast::constant_value_storage::array>(size, value.get_array()[0]);
 				}
 				else
 				{
-					result.emplace<ast::constant_value::array>(size, value);
+					result.emplace<ast::constant_value_storage::array>(size, value);
 				}
 				return result;
 			}
 		},
-		[&expr, &context](ast::expr_array_copy_construct &array_copy_construct_expr) -> ast::constant_value {
+		[&expr, &context](ast::expr_array_copy_construct &array_copy_construct_expr) -> ast::constant_value_storage {
 			consteval_guaranteed(array_copy_construct_expr.copied_value, context);
 			if (!array_copy_construct_expr.copied_value.has_consteval_succeeded())
 			{
@@ -3035,21 +3035,21 @@ static ast::constant_value guaranteed_evaluate_expr(
 				return {};
 			}
 		},
-		[&context](ast::expr_array_move_construct &array_move_construct_expr) -> ast::constant_value {
+		[&context](ast::expr_array_move_construct &array_move_construct_expr) -> ast::constant_value_storage {
 			consteval_guaranteed(array_move_construct_expr.moved_value, context);
 			return {};
 		},
-		[&expr, &context](ast::expr_optional_default_construct &optional_default_construct_expr) -> ast::constant_value {
+		[&expr, &context](ast::expr_optional_default_construct &optional_default_construct_expr) -> ast::constant_value_storage {
 			if (context.is_trivially_destructible(expr.src_tokens, optional_default_construct_expr.type))
 			{
-				return ast::constant_value::get_null();
+				return ast::constant_value_storage::get_null();
 			}
 			else
 			{
 				return {};
 			}
 		},
-		[&expr, &context](ast::expr_optional_copy_construct &optional_copy_construct_expr) -> ast::constant_value {
+		[&expr, &context](ast::expr_optional_copy_construct &optional_copy_construct_expr) -> ast::constant_value_storage {
 			consteval_guaranteed(optional_copy_construct_expr.copied_value, context);
 			if (!optional_copy_construct_expr.copied_value.has_consteval_succeeded())
 			{
@@ -3065,7 +3065,7 @@ static ast::constant_value guaranteed_evaluate_expr(
 				return {};
 			}
 		},
-		[&expr, &context](ast::expr_optional_move_construct &optional_move_construct_expr) -> ast::constant_value {
+		[&expr, &context](ast::expr_optional_move_construct &optional_move_construct_expr) -> ast::constant_value_storage {
 			consteval_guaranteed(optional_move_construct_expr.moved_value, context);
 			if (!optional_move_construct_expr.moved_value.has_consteval_succeeded())
 			{
@@ -3081,11 +3081,11 @@ static ast::constant_value guaranteed_evaluate_expr(
 				return {};
 			}
 		},
-		[](ast::expr_builtin_default_construct &builtin_default_construct_expr) -> ast::constant_value {
+		[](ast::expr_builtin_default_construct &builtin_default_construct_expr) -> ast::constant_value_storage {
 			bz_assert(builtin_default_construct_expr.type.is<ast::ts_array_slice>());
 			return {};
 		},
-		[&context](ast::expr_trivial_copy_construct &trivial_copy_construct_expr) -> ast::constant_value {
+		[&context](ast::expr_trivial_copy_construct &trivial_copy_construct_expr) -> ast::constant_value_storage {
 			consteval_guaranteed(trivial_copy_construct_expr.copied_value, context);
 			if (!trivial_copy_construct_expr.copied_value.has_consteval_succeeded())
 			{
@@ -3094,65 +3094,65 @@ static ast::constant_value guaranteed_evaluate_expr(
 
 			return trivial_copy_construct_expr.copied_value.get_constant_value();
 		},
-		[&context](ast::expr_trivial_relocate &trivial_relocate_expr) -> ast::constant_value {
+		[&context](ast::expr_trivial_relocate &trivial_relocate_expr) -> ast::constant_value_storage {
 			consteval_guaranteed(trivial_relocate_expr.value, context);
 			return {};
 		},
-		[](ast::expr_aggregate_destruct &) -> ast::constant_value {
+		[](ast::expr_aggregate_destruct &) -> ast::constant_value_storage {
 			return {};
 		},
-		[](ast::expr_array_destruct &) -> ast::constant_value {
+		[](ast::expr_array_destruct &) -> ast::constant_value_storage {
 			return {};
 		},
-		[](ast::expr_optional_destruct &) -> ast::constant_value {
+		[](ast::expr_optional_destruct &) -> ast::constant_value_storage {
 			return {};
 		},
-		[](ast::expr_base_type_destruct &) -> ast::constant_value {
+		[](ast::expr_base_type_destruct &) -> ast::constant_value_storage {
 			return {};
 		},
-		[](ast::expr_destruct_value &) -> ast::constant_value {
+		[](ast::expr_destruct_value &) -> ast::constant_value_storage {
 			return {};
 		},
-		[](ast::expr_aggregate_assign &) -> ast::constant_value {
+		[](ast::expr_aggregate_assign &) -> ast::constant_value_storage {
 			return {};
 		},
-		[](ast::expr_array_assign &) -> ast::constant_value {
+		[](ast::expr_array_assign &) -> ast::constant_value_storage {
 			return {};
 		},
-		[](ast::expr_optional_assign &) -> ast::constant_value {
+		[](ast::expr_optional_assign &) -> ast::constant_value_storage {
 			return {};
 		},
-		[](ast::expr_optional_null_assign &) -> ast::constant_value {
+		[](ast::expr_optional_null_assign &) -> ast::constant_value_storage {
 			return {};
 		},
-		[](ast::expr_optional_value_assign &) -> ast::constant_value {
+		[](ast::expr_optional_value_assign &) -> ast::constant_value_storage {
 			return {};
 		},
-		[](ast::expr_optional_reference_value_assign &) -> ast::constant_value {
+		[](ast::expr_optional_reference_value_assign &) -> ast::constant_value_storage {
 			return {};
 		},
-		[](ast::expr_base_type_assign &) -> ast::constant_value {
+		[](ast::expr_base_type_assign &) -> ast::constant_value_storage {
 			return {};
 		},
-		[](ast::expr_trivial_assign &) -> ast::constant_value {
+		[](ast::expr_trivial_assign &) -> ast::constant_value_storage {
 			return {};
 		},
-		[](ast::expr_aggregate_swap &) -> ast::constant_value {
+		[](ast::expr_aggregate_swap &) -> ast::constant_value_storage {
 			return {};
 		},
-		[](ast::expr_array_swap &) -> ast::constant_value {
+		[](ast::expr_array_swap &) -> ast::constant_value_storage {
 			return {};
 		},
-		[](ast::expr_optional_swap &) -> ast::constant_value {
+		[](ast::expr_optional_swap &) -> ast::constant_value_storage {
 			return {};
 		},
-		[](ast::expr_base_type_swap &) -> ast::constant_value {
+		[](ast::expr_base_type_swap &) -> ast::constant_value_storage {
 			return {};
 		},
-		[](ast::expr_trivial_swap &) -> ast::constant_value {
+		[](ast::expr_trivial_swap &) -> ast::constant_value_storage {
 			return {};
 		},
-		[&context](ast::expr_member_access &member_access_expr) -> ast::constant_value {
+		[&context](ast::expr_member_access &member_access_expr) -> ast::constant_value_storage {
 			consteval_guaranteed(member_access_expr.base, context);
 			if (member_access_expr.base.has_consteval_succeeded())
 			{
@@ -3166,7 +3166,7 @@ static ast::constant_value guaranteed_evaluate_expr(
 				return {};
 			}
 		},
-		[&context, &expr](ast::expr_optional_extract_value &optional_extract_value) -> ast::constant_value {
+		[&context, &expr](ast::expr_optional_extract_value &optional_extract_value) -> ast::constant_value_storage {
 			consteval_guaranteed(optional_extract_value.optional_value, context);
 			if (optional_extract_value.optional_value.has_consteval_succeeded())
 			{
@@ -3190,7 +3190,7 @@ static ast::constant_value guaranteed_evaluate_expr(
 				return {};
 			}
 		},
-		[&context](ast::expr_rvalue_member_access &rvalue_member_access_expr) -> ast::constant_value {
+		[&context](ast::expr_rvalue_member_access &rvalue_member_access_expr) -> ast::constant_value_storage {
 			consteval_guaranteed(rvalue_member_access_expr.base, context);
 			if (rvalue_member_access_expr.base.has_consteval_succeeded())
 			{
@@ -3204,24 +3204,24 @@ static ast::constant_value guaranteed_evaluate_expr(
 				return {};
 			}
 		},
-		[](ast::expr_type_member_access &) -> ast::constant_value {
+		[](ast::expr_type_member_access &) -> ast::constant_value_storage {
 			// variable constevalness is handled in parse_context::make_member_access_expression
 			return {};
 		},
-		[&context](ast::expr_compound &compound_expr) -> ast::constant_value {
+		[&context](ast::expr_compound &compound_expr) -> ast::constant_value_storage {
 			if (compound_expr.statements.empty() && compound_expr.final_expr.not_null())
 			{
 				consteval_guaranteed(compound_expr.final_expr, context);
 			}
 			return {};
 		},
-		[&context](ast::expr_if &if_expr) -> ast::constant_value {
+		[&context](ast::expr_if &if_expr) -> ast::constant_value_storage {
 			consteval_guaranteed(if_expr.condition, context);
 			consteval_guaranteed(if_expr.then_block, context);
 			consteval_guaranteed(if_expr.else_block, context);
 			return {};
 		},
-		[&context](ast::expr_if_consteval &if_expr) -> ast::constant_value {
+		[&context](ast::expr_if_consteval &if_expr) -> ast::constant_value_storage {
 			bz_assert(if_expr.condition.is_constant());
 			auto const &condition_value = if_expr.condition.get_constant_value();
 			bz_assert(condition_value.is_boolean());
@@ -3253,10 +3253,10 @@ static ast::constant_value guaranteed_evaluate_expr(
 			}
 			else
 			{
-				return ast::constant_value::get_void();
+				return ast::constant_value_storage::get_void();
 			}
 		},
-		[&context](ast::expr_switch &switch_expr) -> ast::constant_value {
+		[&context](ast::expr_switch &switch_expr) -> ast::constant_value_storage {
 			consteval_guaranteed(switch_expr.matched_expr, context);
 			for (auto &[_, case_expr] : switch_expr.cases)
 			{
@@ -3265,25 +3265,25 @@ static ast::constant_value guaranteed_evaluate_expr(
 			consteval_guaranteed(switch_expr.default_case, context);
 			return {};
 		},
-		[](ast::expr_break &) -> ast::constant_value {
+		[](ast::expr_break &) -> ast::constant_value_storage {
 			return {};
 		},
-		[](ast::expr_continue &) -> ast::constant_value {
+		[](ast::expr_continue &) -> ast::constant_value_storage {
 			return {};
 		},
-		[](ast::expr_unreachable &) -> ast::constant_value {
+		[](ast::expr_unreachable &) -> ast::constant_value_storage {
 			return {};
 		},
-		[](ast::expr_generic_type_instantiation &) -> ast::constant_value {
+		[](ast::expr_generic_type_instantiation &) -> ast::constant_value_storage {
 			bz_unreachable;
 		},
-		[](ast::expr_bitcode_value_reference &) -> ast::constant_value {
+		[](ast::expr_bitcode_value_reference &) -> ast::constant_value_storage {
 			return {};
 		},
 	});
 }
 
-static ast::constant_value try_evaluate_expr(
+static ast::constant_value_storage try_evaluate_expr(
 	ast::expression &expr,
 	ctx::parse_context &context
 )
@@ -3292,7 +3292,7 @@ static ast::constant_value try_evaluate_expr(
 	return context.execute_expression(expr);
 }
 
-static ast::constant_value try_evaluate_expr_without_error(
+static ast::constant_value_storage try_evaluate_expr_without_error(
 	ast::expression &expr,
 	ctx::parse_context &context
 )

--- a/src/resolve/expression_resolver.cpp
+++ b/src/resolve/expression_resolver.cpp
@@ -577,21 +577,21 @@ static ast::expression resolve_expr(
 					switch (rhs_value.kind())
 					{
 					static_assert(ast::constant_value_storage::variant_count == 19);
-					case ast::constant_value_storage::sint:
+					case ast::constant_value_kind::sint:
 						context.report_error(
 							rhs.src_tokens,
 							bz::format("duplicate value {} in switch expression", lhs_value.get_sint()),
 							{ context.make_note(lhs.src_tokens, "value previously used here") }
 						);
 						break;
-					case ast::constant_value_storage::uint:
+					case ast::constant_value_kind::uint:
 						context.report_error(
 							rhs.src_tokens,
 							bz::format("duplicate value {} in switch expression", lhs_value.get_uint()),
 							{ context.make_note(lhs.src_tokens, "value previously used here") }
 						);
 						break;
-					case ast::constant_value_storage::u8char:
+					case ast::constant_value_kind::u8char:
 						context.report_error(
 							rhs.src_tokens,
 							bz::format(
@@ -601,21 +601,21 @@ static ast::expression resolve_expr(
 							{ context.make_note(lhs.src_tokens, "value previously used here") }
 						);
 						break;
-					case ast::constant_value_storage::boolean:
+					case ast::constant_value_kind::boolean:
 						context.report_error(
 							rhs.src_tokens,
 							bz::format("duplicate value '{}' in switch expression", lhs_value.get_boolean()),
 							{ context.make_note(lhs.src_tokens, "value previously used here") }
 						);
 						break;
-					case ast::constant_value_storage::enum_:
+					case ast::constant_value_kind::enum_:
 						context.report_error(
 							rhs.src_tokens,
 							bz::format("duplicate value '{}' in switch expression", get_value_string(lhs_value)),
 							{ context.make_note(lhs.src_tokens, "value previously used here") }
 						);
 						break;
-					case ast::constant_value_storage::string:
+					case ast::constant_value_kind::string:
 						context.report_error(
 							rhs.src_tokens,
 							bz::format("duplicate value {} in switch expression", get_value_string(lhs_value)),
@@ -814,7 +814,7 @@ static ast::expression resolve_expr(
 				switch (size_value.kind())
 				{
 				static_assert(ast::constant_value_storage::variant_count == 19);
-				case ast::constant_value_storage::sint:
+				case ast::constant_value_kind::sint:
 				{
 					auto const value = size_value.get_sint();
 					if (value <= 0)
@@ -827,7 +827,7 @@ static ast::expression resolve_expr(
 					}
 					return static_cast<uint64_t>(value);
 				}
-				case ast::constant_value_storage::uint:
+				case ast::constant_value_kind::uint:
 				{
 					auto const value = size_value.get_uint();
 					if (value == 0)

--- a/src/resolve/expression_resolver.cpp
+++ b/src/resolve/expression_resolver.cpp
@@ -450,7 +450,7 @@ static ast::expression resolve_expr(
 		return ast::make_constant_expression(
 			src_tokens,
 			ast::expression_type_kind::none, ast::typespec(),
-			ast::constant_value::get_void(),
+			ast::constant_value_storage::get_void(),
 			std::move(result_node)
 		);
 	}
@@ -576,22 +576,22 @@ static ast::expression resolve_expr(
 				{
 					switch (rhs_value.kind())
 					{
-					static_assert(ast::constant_value::variant_count == 19);
-					case ast::constant_value::sint:
+					static_assert(ast::constant_value_storage::variant_count == 19);
+					case ast::constant_value_storage::sint:
 						context.report_error(
 							rhs.src_tokens,
 							bz::format("duplicate value {} in switch expression", lhs_value.get_sint()),
 							{ context.make_note(lhs.src_tokens, "value previously used here") }
 						);
 						break;
-					case ast::constant_value::uint:
+					case ast::constant_value_storage::uint:
 						context.report_error(
 							rhs.src_tokens,
 							bz::format("duplicate value {} in switch expression", lhs_value.get_uint()),
 							{ context.make_note(lhs.src_tokens, "value previously used here") }
 						);
 						break;
-					case ast::constant_value::u8char:
+					case ast::constant_value_storage::u8char:
 						context.report_error(
 							rhs.src_tokens,
 							bz::format(
@@ -601,21 +601,21 @@ static ast::expression resolve_expr(
 							{ context.make_note(lhs.src_tokens, "value previously used here") }
 						);
 						break;
-					case ast::constant_value::boolean:
+					case ast::constant_value_storage::boolean:
 						context.report_error(
 							rhs.src_tokens,
 							bz::format("duplicate value '{}' in switch expression", lhs_value.get_boolean()),
 							{ context.make_note(lhs.src_tokens, "value previously used here") }
 						);
 						break;
-					case ast::constant_value::enum_:
+					case ast::constant_value_storage::enum_:
 						context.report_error(
 							rhs.src_tokens,
 							bz::format("duplicate value '{}' in switch expression", get_value_string(lhs_value)),
 							{ context.make_note(lhs.src_tokens, "value previously used here") }
 						);
 						break;
-					case ast::constant_value::string:
+					case ast::constant_value_storage::string:
 						context.report_error(
 							rhs.src_tokens,
 							bz::format("duplicate value {} in switch expression", get_value_string(lhs_value)),
@@ -810,11 +810,11 @@ static ast::expression resolve_expr(
 			}
 			else
 			{
-				ast::constant_value const &size_value = size.get_constant_value();
+				ast::constant_value_storage const &size_value = size.get_constant_value();
 				switch (size_value.kind())
 				{
-				static_assert(ast::constant_value::variant_count == 19);
-				case ast::constant_value::sint:
+				static_assert(ast::constant_value_storage::variant_count == 19);
+				case ast::constant_value_storage::sint:
 				{
 					auto const value = size_value.get_sint();
 					if (value <= 0)
@@ -827,7 +827,7 @@ static ast::expression resolve_expr(
 					}
 					return static_cast<uint64_t>(value);
 				}
-				case ast::constant_value::uint:
+				case ast::constant_value_storage::uint:
 				{
 					auto const value = size_value.get_uint();
 					if (value == 0)
@@ -1045,7 +1045,7 @@ static ast::expression resolve_expr(
 		src_tokens,
 		ast::expression_type_kind::type_name,
 		ast::make_typename_typespec(nullptr),
-		ast::constant_value(std::move(fn_type)),
+		ast::constant_value_storage(std::move(fn_type)),
 		ast::make_expr_typename_literal()
 	);
 }

--- a/src/resolve/statement_resolver.cpp
+++ b/src/resolve/statement_resolver.cpp
@@ -405,7 +405,7 @@ static void resolve_stmt(ast::stmt_static_assert &static_assert_stmt, ctx::parse
 	}
 
 	auto &cond_const_expr = static_assert_stmt.condition.get_constant();
-	bz_assert(cond_const_expr.value.kind() == ast::constant_value::boolean);
+	bz_assert(cond_const_expr.value.is_boolean());
 	auto const cond = cond_const_expr.value.get_boolean();
 
 	if (!cond)
@@ -419,7 +419,7 @@ static void resolve_stmt(ast::stmt_static_assert &static_assert_stmt, ctx::parse
 		if (static_assert_stmt.message.not_null() && static_assert_stmt.message.not_error())
 		{
 			auto &message_const_expr = static_assert_stmt.message.get_constant();
-			bz_assert(message_const_expr.value.kind() == ast::constant_value::string);
+			bz_assert(message_const_expr.value.is_string());
 			auto const message = message_const_expr.value.get_string();
 			error_message += bz::format(", message: '{}'", message);
 		}
@@ -2886,8 +2886,8 @@ static void resolve_literal_init_enum_members_helper(
 		const_literal_expr.kind = ast::expression_type_kind::rvalue;
 		const_literal_expr.type = ast::make_enum_typespec({}, &enum_decl);
 		const_literal_expr.value = it->value.is<int64_t>()
-			? ast::constant_value::get_enum(&enum_decl, it->value.get<int64_t>())
-			: ast::constant_value::get_enum(&enum_decl, it->value.get<uint64_t>());
+			? ast::constant_value_storage::get_enum(&enum_decl, it->value.get<int64_t>())
+			: ast::constant_value_storage::get_enum(&enum_decl, it->value.get<uint64_t>());
 	}
 	else if (
 		auto const already_resolving_it = std::find(resolve_stack.begin(), resolve_stack.end() - 1, current_it);
@@ -2916,8 +2916,8 @@ static void resolve_literal_init_enum_members_helper(
 		const_literal_expr.kind = ast::expression_type_kind::rvalue;
 		const_literal_expr.type = ast::make_enum_typespec({}, &enum_decl);
 		const_literal_expr.value = current_it->value.is<int64_t>()
-			? ast::constant_value::get_enum(&enum_decl, current_it->value.get<int64_t>())
-			: ast::constant_value::get_enum(&enum_decl, current_it->value.get<uint64_t>());
+			? ast::constant_value_storage::get_enum(&enum_decl, current_it->value.get<int64_t>())
+			: ast::constant_value_storage::get_enum(&enum_decl, current_it->value.get<uint64_t>());
 	}
 	else
 	{
@@ -2934,8 +2934,8 @@ static void resolve_literal_init_enum_members_helper(
 		const_literal_expr.kind = ast::expression_type_kind::rvalue;
 		const_literal_expr.type = ast::make_enum_typespec({}, &enum_decl);
 		const_literal_expr.value = it->value.is<int64_t>()
-			? ast::constant_value::get_enum(&enum_decl, it->value.get<int64_t>())
-			: ast::constant_value::get_enum(&enum_decl, it->value.get<uint64_t>());
+			? ast::constant_value_storage::get_enum(&enum_decl, it->value.get<int64_t>())
+			: ast::constant_value_storage::get_enum(&enum_decl, it->value.get<uint64_t>());
 	}
 }
 

--- a/test/consteval_test.cpp
+++ b/test/consteval_test.cpp
@@ -49,21 +49,21 @@ do {                                                                            
     global_ctx.clear_errors_and_warnings();                                     \
 } while (false)
 
-	x("'a'", ast::constant_value::u8char, 'a');
-	x("123", ast::constant_value::sint, 123);
-	x("123u8", ast::constant_value::uint, 123);
-	x("\"hello\"", ast::constant_value::string, "hello");
+	x("'a'", ast::constant_value_kind::u8char, 'a');
+	x("123", ast::constant_value_kind::sint, 123);
+	x("123u8", ast::constant_value_kind::uint, 123);
+	x("\"hello\"", ast::constant_value_kind::string, "hello");
 
-	// x("__builtin_exp_f64(1.5)", ast::constant_value::float64, std::exp(1.5));
-	// x("__builtin_exp_f32(1.5f32)", ast::constant_value::float32, std::exp(1.5f));
-	// x("__builtin_sinh_f32(1.6f32)", ast::constant_value::float32, std::sinh(1.6f));
+	// x("__builtin_exp_f64(1.5)", ast::constant_value_kind::float64, std::exp(1.5));
+	// x("__builtin_exp_f32(1.5f32)", ast::constant_value_kind::float32, std::exp(1.5f));
+	// x("__builtin_sinh_f32(1.6f32)", ast::constant_value_kind::float32, std::sinh(1.6f));
 
 	x_fail("{ 0; __builtin_exp_f64(1.5) }");
 	x_fail("{ 0; __builtin_exp_f32(1.5f32) }");
 	x_fail("{ 0; __builtin_sinh_f32(1.6f32) }");
 
-	x("3 + 4", ast::constant_value::sint, 7);
-	x("3 / 4", ast::constant_value::sint, 0);
+	x("3 + 4", ast::constant_value_kind::sint, 7);
+	x("3 / 4", ast::constant_value_kind::sint, 0);
 	x_fail("3 / 0");
 	x_fail("3u32 << 32");
 
@@ -116,16 +116,16 @@ do {                                                                            
     global_ctx.clear_errors_and_warnings();                                     \
 } while (false)
 
-	x("'a'", ast::constant_value::u8char, 'a');
-	x("123", ast::constant_value::sint, 123);
-	x("123u8", ast::constant_value::uint, 123);
-	x("\"hello\"", ast::constant_value::string, "hello");
-	x("__builtin_exp_f64(1.5)",        ast::constant_value::float64, std::exp(1.5));
-	x("{ 0; __builtin_exp_f64(1.5) }", ast::constant_value::float64, std::exp(1.5));
-	x("__builtin_exp_f32(1.5f32)",        ast::constant_value::float32, std::exp(1.5f));
-	x("{ 0; __builtin_exp_f32(1.5f32) }", ast::constant_value::float32, std::exp(1.5f));
-	x("__builtin_sinh_f32(1.6f32)",        ast::constant_value::float32, std::sinh(1.6f));
-	x("{ 0; __builtin_sinh_f32(1.6f32) }", ast::constant_value::float32, std::sinh(1.6f));
+	x("'a'", ast::constant_value_kind::u8char, 'a');
+	x("123", ast::constant_value_kind::sint, 123);
+	x("123u8", ast::constant_value_kind::uint, 123);
+	x("\"hello\"", ast::constant_value_kind::string, "hello");
+	x("__builtin_exp_f64(1.5)",        ast::constant_value_kind::float64, std::exp(1.5));
+	x("{ 0; __builtin_exp_f64(1.5) }", ast::constant_value_kind::float64, std::exp(1.5));
+	x("__builtin_exp_f32(1.5f32)",        ast::constant_value_kind::float32, std::exp(1.5f));
+	x("{ 0; __builtin_exp_f32(1.5f32) }", ast::constant_value_kind::float32, std::exp(1.5f));
+	x("__builtin_sinh_f32(1.6f32)",        ast::constant_value_kind::float32, std::sinh(1.6f));
+	x("{ 0; __builtin_sinh_f32(1.6f32) }", ast::constant_value_kind::float32, std::sinh(1.6f));
 	x(R"({
 		function factorial(n) -> typeof n
 		{
@@ -138,7 +138,7 @@ do {                                                                            
 			return result;
 		}
 		factorial(10)
-	})", ast::constant_value::sint, 3628800);
+	})", ast::constant_value_kind::sint, 3628800);
 	x(R"({
 		function factorial(n) -> typeof n
 		{
@@ -151,7 +151,7 @@ do {                                                                            
 			return result;
 		}
 		factorial(10u)
-	})", ast::constant_value::uint, 3628800);
+	})", ast::constant_value_kind::uint, 3628800);
 	x(R"({
 		function foo() -> [10: int32]
 		{
@@ -164,7 +164,7 @@ do {                                                                            
 		}
 		consteval vals = foo();
 		vals[3]
-	})", ast::constant_value::sint, 3);
+	})", ast::constant_value_kind::sint, 3);
 
 	x_fail(R"({ if (x) { 0 } else { 1 } })");
 	x_fail(R"asdf({

--- a/test/parser_test.cpp
+++ b/test/parser_test.cpp
@@ -78,7 +78,7 @@ do {                                                                            
         lex::token_range{},                                                          \
         ast::var_id_and_type(                                                        \
             ast::make_identifier(id),                                                \
-            ast::type_as_expression(                                                 \
+            parse_ctx.type_as_expression(                                            \
                 lex::src_tokens::from_range(type_token_range),                       \
                 ast::make_unresolved_typespec(type_token_range)                      \
             )                                                                        \
@@ -165,86 +165,86 @@ xx_compiles(                                                                    
 	x("a");
 	x_err("this_doesnt_exist");
 
-	x_const_expr("42", ast::type_info::int32_, ast::constant_value::sint, 42);
+	x_const_expr("42", ast::type_info::int32_, ast::constant_value_kind::sint, 42);
 	auto const min_int64_val = static_cast<int64_t>(std::numeric_limits<int32_t>::max()) + 1;
 	auto const min_int64_str = bz::format("{}", min_int64_val);
-	x_const_expr(min_int64_str, ast::type_info::int64_, ast::constant_value::sint, min_int64_val);
+	x_const_expr(min_int64_str, ast::type_info::int64_, ast::constant_value_kind::sint, min_int64_val);
 	auto const min_uint64_val = static_cast<uint64_t>(std::numeric_limits<int64_t>::max()) + 1;
 	auto const min_uint64_str = bz::format("{}", min_uint64_val);
-	x_const_expr(min_uint64_str, ast::type_info::uint64_, ast::constant_value::uint, min_uint64_val);
+	x_const_expr(min_uint64_str, ast::type_info::uint64_, ast::constant_value_kind::uint, min_uint64_val);
 	x_err("999999999999999999999999999");
 
 	x_err("32i123456");
 
-	x_const_expr("42i8",  ast::type_info::int8_,  ast::constant_value::sint, 42);
-	x_const_expr("42i16", ast::type_info::int16_, ast::constant_value::sint, 42);
-	x_const_expr("42i32", ast::type_info::int32_, ast::constant_value::sint, 42);
-	x_const_expr("42i64", ast::type_info::int64_, ast::constant_value::sint, 42);
-	x_const_expr("42u8",  ast::type_info::uint8_,  ast::constant_value::uint, 42);
-	x_const_expr("42u16", ast::type_info::uint16_, ast::constant_value::uint, 42);
-	x_const_expr("42u32", ast::type_info::uint32_, ast::constant_value::uint, 42);
-	x_const_expr("42u64", ast::type_info::uint64_, ast::constant_value::uint, 42);
+	x_const_expr("42i8",  ast::type_info::int8_,  ast::constant_value_kind::sint, 42);
+	x_const_expr("42i16", ast::type_info::int16_, ast::constant_value_kind::sint, 42);
+	x_const_expr("42i32", ast::type_info::int32_, ast::constant_value_kind::sint, 42);
+	x_const_expr("42i64", ast::type_info::int64_, ast::constant_value_kind::sint, 42);
+	x_const_expr("42u8",  ast::type_info::uint8_,  ast::constant_value_kind::uint, 42);
+	x_const_expr("42u16", ast::type_info::uint16_, ast::constant_value_kind::uint, 42);
+	x_const_expr("42u32", ast::type_info::uint32_, ast::constant_value_kind::uint, 42);
+	x_const_expr("42u64", ast::type_info::uint64_, ast::constant_value_kind::uint, 42);
 	x_err("128i8");
 
-	x_const_expr("1.5", ast::type_info::float64_, ast::constant_value::float64, 1.5);
+	x_const_expr("1.5", ast::type_info::float64_, ast::constant_value_kind::float64, 1.5);
 	x_err("1.5f123456");
 
-	x_const_expr("1.5f32", ast::type_info::float32_, ast::constant_value::float32, 1.5f);
-	x_const_expr("1.5f64", ast::type_info::float64_, ast::constant_value::float64, 1.5);
+	x_const_expr("1.5f32", ast::type_info::float32_, ast::constant_value_kind::float32, 1.5f);
+	x_const_expr("1.5f64", ast::type_info::float64_, ast::constant_value_kind::float64, 1.5);
 
-	x_const_expr("0x42", ast::type_info::uint32_, ast::constant_value::uint, 0x42);
-	x_const_expr("0x1234'5678'90ab'cdef", ast::type_info::uint64_, ast::constant_value::uint, 0x1234'5678'90ab'cdef);
+	x_const_expr("0x42", ast::type_info::uint32_, ast::constant_value_kind::uint, 0x42);
+	x_const_expr("0x1234'5678'90ab'cdef", ast::type_info::uint64_, ast::constant_value_kind::uint, 0x1234'5678'90ab'cdef);
 	x_err("0x1'1234'5678'90ab'cdef");
-	x_const_expr("0x42i8", ast::type_info::int8_, ast::constant_value::sint, 0x42);
+	x_const_expr("0x42i8", ast::type_info::int8_, ast::constant_value_kind::sint, 0x42);
 	x_err("0xffi8");
 	x_err("0x1'ffff'ffff'ffff'ffff");
 
-	x_const_expr("0o42", ast::type_info::uint32_, ast::constant_value::uint, (4 * 8 + 2));
+	x_const_expr("0o42", ast::type_info::uint32_, ast::constant_value_kind::uint, (4 * 8 + 2));
 	auto const min_uint64_oct_str = bz::format("0o{:o}", uint64_t(1) << 32);
-	x_const_expr(min_uint64_oct_str, ast::type_info::uint64_, ast::constant_value::uint, static_cast<uint64_t>(1ull << 32));
-	x_const_expr("0o42i8", ast::type_info::int8_, ast::constant_value::sint, (4 * 8 + 2));
+	x_const_expr(min_uint64_oct_str, ast::type_info::uint64_, ast::constant_value_kind::uint, static_cast<uint64_t>(1ull << 32));
+	x_const_expr("0o42i8", ast::type_info::int8_, ast::constant_value_kind::sint, (4 * 8 + 2));
 	x_err("0o200i8");
 
-	x_const_expr("0b1010'0101", ast::type_info::uint32_, ast::constant_value::uint, 0b1010'0101);
-	x_const_expr("0b'1'0000'0000'0000'0000'0000'0000'0000'0000", ast::type_info::uint64_, ast::constant_value::uint, 1ull << 32);
-	x_const_expr("0b0110'0101'i8", ast::type_info::int8_, ast::constant_value::sint, 0b0110'0101);
+	x_const_expr("0b1010'0101", ast::type_info::uint32_, ast::constant_value_kind::uint, 0b1010'0101);
+	x_const_expr("0b'1'0000'0000'0000'0000'0000'0000'0000'0000", ast::type_info::uint64_, ast::constant_value_kind::uint, 1ull << 32);
+	x_const_expr("0b0110'0101'i8", ast::type_info::int8_, ast::constant_value_kind::sint, 0b0110'0101);
 	x_err("0b1000'0000'i8");
 	x_err("0b'1''0000'0000''0000'0000''0000'0000''0000'0000''''0000'0000''0000'0000''0000'0000''0000'0000");
 
-	x_const_expr("'a'", ast::type_info::char_, ast::constant_value::u8char, 'a');
+	x_const_expr("'a'", ast::type_info::char_, ast::constant_value_kind::u8char, 'a');
 	x_err("'a'asdf");
-	x_const_expr("'\\x7f'", ast::type_info::char_, ast::constant_value::u8char, 0x7f);
-	x_const_expr("'\\u0470'", ast::type_info::char_, ast::constant_value::u8char, 0x470);
-	x_const_expr("'\\U00000470'", ast::type_info::char_, ast::constant_value::u8char, 0x470);
-	x_const_expr("'Ѱ'", ast::type_info::char_, ast::constant_value::u8char, 0x470);
+	x_const_expr("'\\x7f'", ast::type_info::char_, ast::constant_value_kind::u8char, 0x7f);
+	x_const_expr("'\\u0470'", ast::type_info::char_, ast::constant_value_kind::u8char, 0x470);
+	x_const_expr("'\\U00000470'", ast::type_info::char_, ast::constant_value_kind::u8char, 0x470);
+	x_const_expr("'Ѱ'", ast::type_info::char_, ast::constant_value_kind::u8char, 0x470);
 //	x_err("'\\U000110000'", 1); // this is handled while lexing
 
-	x_const_expr("true", ast::type_info::bool_, ast::constant_value::boolean, true);
-	x_const_expr("false", ast::type_info::bool_, ast::constant_value::boolean, false);
-	x_const_expr("null", ast::type_info::null_t_, ast::constant_value::null, ast::internal::null_t{});
+	x_const_expr("true", ast::type_info::bool_, ast::constant_value_kind::boolean, true);
+	x_const_expr("false", ast::type_info::bool_, ast::constant_value_kind::boolean, false);
+	x_const_expr("null", ast::type_info::null_t_, ast::constant_value_kind::null, ast::internal::null_t{});
 
-	x_const_expr(R"( "" )", ast::type_info::str_, ast::constant_value::string, "");
-	x_const_expr(R"( "hello!!" )", ast::type_info::str_, ast::constant_value::string, "hello!!");
-	x_const_expr(R"( "hello	!!" )", ast::type_info::str_, ast::constant_value::string, "hello\t!!");
-	x_const_expr(R"( "hello\t!!" )", ast::type_info::str_, ast::constant_value::string, "hello\t!!");
-	x_const_expr(R"( "hello!!\u0470" )", ast::type_info::str_, ast::constant_value::string, "hello!!Ѱ");
-	x_const_expr(R"( "hello" " again" " and again!" )", ast::type_info::str_, ast::constant_value::string, "hello again and again!");
+	x_const_expr(R"( "" )", ast::type_info::str_, ast::constant_value_kind::string, "");
+	x_const_expr(R"( "hello!!" )", ast::type_info::str_, ast::constant_value_kind::string, "hello!!");
+	x_const_expr(R"( "hello	!!" )", ast::type_info::str_, ast::constant_value_kind::string, "hello\t!!");
+	x_const_expr(R"( "hello\t!!" )", ast::type_info::str_, ast::constant_value_kind::string, "hello\t!!");
+	x_const_expr(R"( "hello!!\u0470" )", ast::type_info::str_, ast::constant_value_kind::string, "hello!!Ѱ");
+	x_const_expr(R"( "hello" " again" " and again!" )", ast::type_info::str_, ast::constant_value_kind::string, "hello again and again!");
 
 
 	x("(0)");
 	x_err("(0 0)");
 	x_err("()");
 
-	x_const_expr("+42", ast::type_info::int32_, ast::constant_value::sint, 42);
+	x_const_expr("+42", ast::type_info::int32_, ast::constant_value_kind::sint, 42);
 	x_err("+ 'a'");
 
-	x_const_expr("-42", ast::type_info::int32_, ast::constant_value::sint, -42);
+	x_const_expr("-42", ast::type_info::int32_, ast::constant_value_kind::sint, -42);
 	x_err("-42u32");
 	x_warn("-(-128 as int8)");
 	auto const max_int64 = std::numeric_limits<int64_t>::max();
 	auto const test_str = bz::format("-(-{}i64 - 1)", max_int64);
 	x_warn(test_str);
-	x_const_expr(test_str, ast::type_info::int64_, ast::constant_value::sint, std::numeric_limits<int64_t>::min());
+	x_const_expr(test_str, ast::type_info::int64_, ast::constant_value_kind::sint, std::numeric_limits<int64_t>::min());
 
 	declare_var("a", "mut int32", "");
 	x("++a");
@@ -265,16 +265,16 @@ xx_compiles(                                                                    
 	x_err("--const_a");
 	x_err("--0");
 
-	x_const_expr("~0u8", ast::type_info::uint8_, ast::constant_value::uint, 255);
-	x_const_expr("~1u32", ast::type_info::uint32_, ast::constant_value::uint, std::numeric_limits<uint32_t>::max() - 1);
-	x_const_expr("~0b1100'0011u8", ast::type_info::uint8_, ast::constant_value::uint, 0b0011'1100u);
-	x_const_expr("~false", ast::type_info::bool_, ast::constant_value::boolean, true);
+	x_const_expr("~0u8", ast::type_info::uint8_, ast::constant_value_kind::uint, 255);
+	x_const_expr("~1u32", ast::type_info::uint32_, ast::constant_value_kind::uint, std::numeric_limits<uint32_t>::max() - 1);
+	x_const_expr("~0b1100'0011u8", ast::type_info::uint8_, ast::constant_value_kind::uint, 0b0011'1100u);
+	x_const_expr("~false", ast::type_info::bool_, ast::constant_value_kind::boolean, true);
 	x_err("~0i32");
 	x_err("~0");
 	x_err("~' '");
 
-	x_const_expr("!true", ast::type_info::bool_, ast::constant_value::boolean, false);
-	x_const_expr("!!true", ast::type_info::bool_, ast::constant_value::boolean, true);
+	x_const_expr("!true", ast::type_info::bool_, ast::constant_value_kind::boolean, false);
+	x_const_expr("!!true", ast::type_info::bool_, ast::constant_value_kind::boolean, true);
 	x_err("!0");
 	x_err("!null");
 	x_err("!' '");
@@ -292,11 +292,11 @@ xx_compiles(                                                                    
 
 
 
-	x_const_expr("+3", ast::type_info::int32_, ast::constant_value::sint, 3);
-	x_const_expr("!!!!!!true", ast::type_info::bool_, ast::constant_value::boolean, true);
-	x_const_expr("(0)", ast::type_info::int32_, ast::constant_value::sint, 0);
-	x_const_expr("((((!true))))", ast::type_info::bool_, ast::constant_value::boolean, false);
-	x_const_expr("+ + - - 42i8", ast::type_info::int8_, ast::constant_value::sint, 42);
+	x_const_expr("+3", ast::type_info::int32_, ast::constant_value_kind::sint, 3);
+	x_const_expr("!!!!!!true", ast::type_info::bool_, ast::constant_value_kind::boolean, true);
+	x_const_expr("(0)", ast::type_info::int32_, ast::constant_value_kind::sint, 0);
+	x_const_expr("((((!true))))", ast::type_info::bool_, ast::constant_value_kind::boolean, false);
+	x_const_expr("+ + - - 42i8", ast::type_info::int8_, ast::constant_value_kind::sint, 42);
 //	x("sizeof 0");
 
 
@@ -1010,33 +1010,33 @@ xx_compiles(                                                                    
 )
 
 #define x_const_expr_bool(str, value)                                         \
-x_const_expr(str, ast::type_info::bool_, ast::constant_value::boolean, value)
+x_const_expr(str, ast::type_info::bool_, ast::constant_value_kind::boolean, value)
 
 
-	x_const_expr("40 + 2", ast::constant_value::sint, 42);
-	x_const_expr("40u32 + 2u32", ast::constant_value::uint, 42u);
-	x_const_expr("255u8 + 3u8", ast::constant_value::uint, uint8_t(258));
+	x_const_expr("40 + 2", ast::constant_value_kind::sint, 42);
+	x_const_expr("40u32 + 2u32", ast::constant_value_kind::uint, 42u);
+	x_const_expr("255u8 + 3u8", ast::constant_value_kind::uint, uint8_t(258));
 	x_warn("255u8 + 3u8");
 	x("((255u8 + 3u8))");
-	x_const_expr("~0u64", ast::constant_value::uint, std::numeric_limits<uint64_t>::max());
+	x_const_expr("~0u64", ast::constant_value_kind::uint, std::numeric_limits<uint64_t>::max());
 
 /*
-	x_const_expr("42", ast::type_info::int32_, ast::constant_value::sint, 42);
-	x_const_expr("40 + 2", ast::type_info::int32_, ast::constant_value::sint, 42);
-	x_const_expr("40 as uint32", ast::type_info::uint32_, ast::constant_value::uint, 40);
-	x_const_expr("257 as uint8", ast::type_info::uint8_, ast::constant_value::uint, 1);
+	x_const_expr("42", ast::type_info::int32_, ast::constant_value_kind::sint, 42);
+	x_const_expr("40 + 2", ast::type_info::int32_, ast::constant_value_kind::sint, 42);
+	x_const_expr("40 as uint32", ast::type_info::uint32_, ast::constant_value_kind::uint, 40);
+	x_const_expr("257 as uint8", ast::type_info::uint8_, ast::constant_value_kind::uint, 1);
 
-	x_const_expr("255u8 + 1u16", ast::type_info::uint16_, ast::constant_value::uint, 256);
-	x_const_expr("500 * 500", ast::type_info::int32_, ast::constant_value::sint, 250'000);
-	x_const_expr("500u32 * 100u8", ast::type_info::uint32_, ast::constant_value::uint, 50'000);
-	x_const_expr("100u8 * 500u32", ast::type_info::uint32_, ast::constant_value::uint, 50'000);
-	x_const_expr("500 / 500", ast::type_info::int32_, ast::constant_value::sint, 1);
-	x_const_expr("500u32 / 100u8", ast::type_info::uint32_, ast::constant_value::uint, 5);
-	x_const_expr("100u8 / 500u32", ast::type_info::uint32_, ast::constant_value::uint, 0);
-	x_const_expr("500 % 500", ast::type_info::int32_, ast::constant_value::sint, 0);
-	x_const_expr("13 % 9", ast::type_info::int32_, ast::constant_value::sint, 4);
-	x_const_expr("500u32 % 100u8", ast::type_info::uint32_, ast::constant_value::uint, 0);
-	x_const_expr("100u8 % 500u32", ast::type_info::uint32_, ast::constant_value::uint, 100);
+	x_const_expr("255u8 + 1u16", ast::type_info::uint16_, ast::constant_value_kind::uint, 256);
+	x_const_expr("500 * 500", ast::type_info::int32_, ast::constant_value_kind::sint, 250'000);
+	x_const_expr("500u32 * 100u8", ast::type_info::uint32_, ast::constant_value_kind::uint, 50'000);
+	x_const_expr("100u8 * 500u32", ast::type_info::uint32_, ast::constant_value_kind::uint, 50'000);
+	x_const_expr("500 / 500", ast::type_info::int32_, ast::constant_value_kind::sint, 1);
+	x_const_expr("500u32 / 100u8", ast::type_info::uint32_, ast::constant_value_kind::uint, 5);
+	x_const_expr("100u8 / 500u32", ast::type_info::uint32_, ast::constant_value_kind::uint, 0);
+	x_const_expr("500 % 500", ast::type_info::int32_, ast::constant_value_kind::sint, 0);
+	x_const_expr("13 % 9", ast::type_info::int32_, ast::constant_value_kind::sint, 4);
+	x_const_expr("500u32 % 100u8", ast::type_info::uint32_, ast::constant_value_kind::uint, 0);
+	x_const_expr("100u8 % 500u32", ast::type_info::uint32_, ast::constant_value_kind::uint, 100);
 	x_const_expr_bool("0 == 0", true);
 	x_const_expr_bool("0 == 1", false);
 	x_const_expr_bool("0u8 == 300u16", false);

--- a/test/test.h
+++ b/test/test.h
@@ -35,46 +35,46 @@ inline std::ostream &operator << (std::ostream &os, ast::constant_value const &v
 {
 	switch (value.kind())
 	{
-	case ast::constant_value::sint:
+	case ast::constant_value_kind::sint:
 		os << "sint: " << value.get_sint();
 		break;
-	case ast::constant_value::uint:
+	case ast::constant_value_kind::uint:
 		os << "uint: " << value.get_uint();
 		break;
-	case ast::constant_value::float32:
+	case ast::constant_value_kind::float32:
 		os << "float32: " << value.get_float32();
 		break;
-	case ast::constant_value::float64:
+	case ast::constant_value_kind::float64:
 		os << "float64: " << value.get_float64();
 		break;
-	case ast::constant_value::u8char:
+	case ast::constant_value_kind::u8char:
 		os << "u8char: " << value.get_u8char();
 		break;
-	case ast::constant_value::string:
+	case ast::constant_value_kind::string:
 		os << "string: " << value.get_string();
 		break;
-	case ast::constant_value::boolean:
+	case ast::constant_value_kind::boolean:
 		os << "boolean: " << value.get_boolean();
 		break;
-	case ast::constant_value::null:
+	case ast::constant_value_kind::null:
 		os << "null: []";
 		break;
-	case ast::constant_value::void_:
+	case ast::constant_value_kind::void_:
 		os << "void: []";
 		break;
-	case ast::constant_value::array:
+	case ast::constant_value_kind::array:
 		os << "array: [...]";
 		break;
-	case ast::constant_value::tuple:
+	case ast::constant_value_kind::tuple:
 		os << "tuple: [...]";
 		break;
-	case ast::constant_value::function:
+	case ast::constant_value_kind::function:
 		os << "function: " << value.get_function()->get_signature();
 		break;
-	case ast::constant_value::type:
+	case ast::constant_value_kind::type:
 		os << "type: " << bz::format("{}", value.get_type());
 		break;
-	case ast::constant_value::aggregate:
+	case ast::constant_value_kind::aggregate:
 		os << "aggreate: [...]";
 		break;
 	default:


### PR DESCRIPTION
`ast::constant_value` is now a light-ish weight value, that is trivially copyable.